### PR TITLE
Add 10 advanced Cython problem pairs demonstrating cdef class, enum, …

### DIFF
--- a/.benchmark_cache.json
+++ b/.benchmark_cache.json
@@ -368,7 +368,17 @@
     "kolmogorov_smirnov": "e56ad6f42009ba7c",
     "spearman_rank": "8298d852836ed0bc",
     "cocktail_sort": "81e58ad2aedaaa23",
-    "mann_whitney_u": "042be84a20290920"
+    "mann_whitney_u": "042be84a20290920",
+    "ring_buffer_mean": "a5b1eb39186938ce",
+    "rpn_eval": "3ebaee9f495c9c8f",
+    "deque_sliding_max": "999e0930b53941b3",
+    "polygon_area_centroid": "9aec430685450cb6",
+    "memview_weighted_sum": "952d67b1fe52bced",
+    "heap_kth_smallest": "8fc92a80ba3199d8",
+    "classify_transitions": "f3bae68487d89a4e",
+    "image_flip_checksum": "753b893cd7c5c310",
+    "particle_bounce": "d6783017dd875625",
+    "matrix_power_trace": "b69369eea86e8bc5"
   },
   "results": {
     "binary_search_count": [
@@ -5029,6 +5039,126 @@
         "cy_avg": 0.003351538232527673,
         "cy_std": 2.1038293663178794e-05,
         "speedup": 60.74857468666469
+      }
+    ],
+    "ring_buffer_mean": [
+      {
+        "benchmark": "ring_buffer_mean",
+        "category": "algorithms",
+        "syntax": "cython",
+        "py_avg": 0.014484609919600188,
+        "py_std": 0.0016086051522576457,
+        "cy_avg": 0.0007368912221863866,
+        "cy_std": 9.924000263125574e-07,
+        "speedup": 19.656374622870054
+      }
+    ],
+    "rpn_eval": [
+      {
+        "benchmark": "rpn_eval",
+        "category": "algorithms",
+        "syntax": "cython",
+        "py_avg": 0.020975751196965577,
+        "py_std": 0.0029230465772433953,
+        "cy_avg": 0.006347112613730133,
+        "cy_std": 6.235474675765447e-05,
+        "speedup": 3.3047706057067017
+      }
+    ],
+    "deque_sliding_max": [
+      {
+        "benchmark": "deque_sliding_max",
+        "category": "algorithms",
+        "syntax": "cython",
+        "py_avg": 0.018696969212032854,
+        "py_std": 0.00025028077988234487,
+        "cy_avg": 0.0019577596802264454,
+        "cy_std": 3.692286973155324e-05,
+        "speedup": 9.550186062607162
+      }
+    ],
+    "polygon_area_centroid": [
+      {
+        "benchmark": "polygon_area_centroid",
+        "category": "geometry",
+        "syntax": "cython",
+        "py_avg": 0.031323022511787715,
+        "py_std": 0.0005457313607552815,
+        "cy_avg": 0.005434201518073678,
+        "cy_std": 0.00011368386341033924,
+        "speedup": 5.764052438543195
+      }
+    ],
+    "memview_weighted_sum": [
+      {
+        "benchmark": "memview_weighted_sum",
+        "category": "numerical",
+        "syntax": "cython",
+        "py_avg": 0.01126094104256481,
+        "py_std": 0.0001534322205402389,
+        "cy_avg": 0.00037751696072518826,
+        "cy_std": 8.18419256221036e-06,
+        "speedup": 29.828967209667063
+      }
+    ],
+    "heap_kth_smallest": [
+      {
+        "benchmark": "heap_kth_smallest",
+        "category": "sorting",
+        "syntax": "cython",
+        "py_avg": 0.011785388947464526,
+        "py_std": 0.0005830007772012408,
+        "cy_avg": 0.0002126897219568491,
+        "cy_std": 6.673223461265127e-06,
+        "speedup": 55.411182256637524
+      }
+    ],
+    "classify_transitions": [
+      {
+        "benchmark": "classify_transitions",
+        "category": "string_processing",
+        "syntax": "cython",
+        "py_avg": 0.012843978102318942,
+        "py_std": 0.0002221314273909492,
+        "cy_avg": 0.0058364807162433864,
+        "cy_std": 8.637289915862964e-05,
+        "speedup": 2.200637460614431
+      }
+    ],
+    "image_flip_checksum": [
+      {
+        "benchmark": "image_flip_checksum",
+        "category": "image_processing",
+        "syntax": "cython",
+        "py_avg": 0.06696944462601095,
+        "py_std": 0.0009911254195427025,
+        "cy_avg": 0.016294164513237775,
+        "cy_std": 0.0001640858810115395,
+        "speedup": 4.110026296322426
+      }
+    ],
+    "particle_bounce": [
+      {
+        "benchmark": "particle_bounce",
+        "category": "simulation",
+        "syntax": "cython",
+        "py_avg": 0.07242127920035273,
+        "py_std": 0.0007899259214783316,
+        "cy_avg": 0.005558925308287143,
+        "cy_std": 7.031517060754699e-06,
+        "speedup": 13.027928094732342
+      }
+    ],
+    "matrix_power_trace": [
+      {
+        "benchmark": "matrix_power_trace",
+        "category": "numerical",
+        "syntax": "cython",
+        "py_avg": 0.31234985913615676,
+        "py_std": 0.0021204299476684065,
+        "cy_avg": 0.005034072790294886,
+        "cy_std": 8.49169695318121e-06,
+        "speedup": 62.047147935232765
       }
     ]
   }

--- a/benchmarks.md
+++ b/benchmarks.md
@@ -142,6 +142,7 @@
 | algorithms | kadane_2d | cython | 242.230 | 3.756 | 64.5x |
 | optimization | simulated_annealing_tsp | cython | 92.268 | 1.457 | 63.3x |
 | simulation | game_of_life_births | cython | 431.392 | 6.863 | 62.9x |
+| numerical | matrix_power_trace | cython | 312.350 | 5.034 | 62.0x |
 | statistics | mann_whitney_u | cython | 203.601 | 3.352 | 60.7x |
 | algorithms | levenshtein_automaton | cython | 304.982 | 5.023 | 60.7x |
 | simulation | reaction_diffusion | cython | 161.091 | 2.677 | 60.2x |
@@ -157,6 +158,7 @@
 | compression | rle_compress_int | cython | 154.536 | 2.727 | 56.7x |
 | simulation | fluid_1d | cython | 179.178 | 3.217 | 55.7x |
 | geometry | point_in_polygon | cython | 393.431 | 7.098 | 55.4x |
+| sorting | heap_kth_smallest | cython | 11.785 | 0.213 | 55.4x |
 | leetcode | max_subarray | cython | 279.084 | 5.085 | 54.9x |
 | dsp | autocorrelation | cython | 282.822 | 5.186 | 54.5x |
 | nn_ops | conv1d | simd | 390.491 | 7.162 | 54.5x |
@@ -228,6 +230,7 @@
 | math_problems | abundant_numbers | cython | 91.509 | 3.013 | 30.4x |
 | graph | graph_coloring_greedy | cython | 99.084 | 3.309 | 29.9x |
 | sorting | tim_sort_merge | cython | 398.857 | 13.343 | 29.9x |
+| numerical | memview_weighted_sum | cython | 11.261 | 0.378 | 29.8x |
 | math_problems | extended_gcd_batch | cython | 347.256 | 11.657 | 29.8x |
 | graph | dijkstra | cython | 470.243 | 15.823 | 29.7x |
 | nn_ops | embedding_lookup | cython | 393.678 | 13.429 | 29.3x |
@@ -275,6 +278,7 @@
 | simulation | langtons_ant | cython | 24.698 | 1.241 | 19.9x |
 | physics | blackbody_radiation | cython | 87.990 | 4.451 | 19.8x |
 | math_problems | lucas_numbers | cython | 163.226 | 8.257 | 19.8x |
+| algorithms | ring_buffer_mean | cython | 14.485 | 0.737 | 19.7x |
 | algorithms | fibonacci | cython | 25.518 | 1.300 | 19.6x |
 | sorting | introsort | cython | 145.159 | 7.607 | 19.1x |
 | dsp | spectral_centroid | cython | 689.344 | 36.380 | 18.9x |
@@ -308,6 +312,7 @@
 | optimization | gradient_descent | cython | 57.644 | 4.331 | 13.3x |
 | simulation | epidemic_sir | cython | 0.044 | 0.003 | 13.2x |
 | diff_equations | shooting_method | cython | 207.357 | 15.860 | 13.1x |
+| simulation | particle_bounce | cython | 72.421 | 5.559 | 13.0x |
 | nn_ops | global_avg_pool | simd | 73.520 | 5.673 | 13.0x |
 | sorting | cocktail_sort | cython | 145.200 | 11.234 | 12.9x |
 | nn_ops | relu | cython | 417.032 | 32.865 | 12.7x |
@@ -341,6 +346,7 @@
 | algorithms | dutch_national_flag | cython | 339.113 | 35.146 | 9.6x |
 | statistics | pearson_correlation | cython | 233.392 | 24.377 | 9.6x |
 | physics | capacitor_discharge | cython | 283.848 | 29.658 | 9.6x |
+| algorithms | deque_sliding_max | cython | 18.697 | 1.958 | 9.6x |
 | algorithms | radix_sort | cython | 22.039 | 2.322 | 9.5x |
 | dsp | goertzel | cython | 127.587 | 13.790 | 9.3x |
 | dsp | window_functions | cython | 141.240 | 15.738 | 9.0x |
@@ -369,16 +375,19 @@
 | numerical | running_mean | cython | 7.839 | 1.168 | 6.7x |
 | math_problems | miller_rabin | cython | 79.888 | 12.631 | 6.3x |
 | cryptography | vigenere_cipher | cython | 58.275 | 10.098 | 5.8x |
+| geometry | polygon_area_centroid | cython | 31.323 | 5.434 | 5.8x |
 | simulation | brownian_motion | cython | 248.200 | 45.364 | 5.5x |
 | numerical | ewma | cython | 37.432 | 7.030 | 5.3x |
 | sorting | pigeonhole_sort | cython | 406.402 | 79.669 | 5.1x |
 | dynamic_programming | longest_increasing_subseq | cython | 5.864 | 1.247 | 4.7x |
 | algorithms | counting_sort | cython | 68.014 | 16.330 | 4.2x |
+| image_processing | image_flip_checksum | cython | 66.969 | 16.294 | 4.1x |
 | math_problems | euler_totient_sieve | cython | 14.583 | 3.789 | 3.8x |
 | string_processing | manacher | cython | 331.138 | 88.428 | 3.7x |
 | dynamic_programming | max_product_subarray | cython | 24.600 | 6.801 | 3.6x |
 | cryptography | xtea_encrypt | cython | 477.430 | 137.746 | 3.5x |
 | numerical | cumulative_sum | cython | 27.298 | 8.052 | 3.4x |
+| algorithms | rpn_eval | cython | 20.976 | 6.347 | 3.3x |
 | cryptography | tea_encrypt | cython | 410.283 | 126.129 | 3.3x |
 | cryptography | xtea | cython | 752.308 | 232.521 | 3.2x |
 | compression | burrows_wheeler_rle | cython | 130.826 | 42.110 | 3.1x |
@@ -388,6 +397,7 @@
 | numerical | prefix_max | cython | 20.281 | 8.185 | 2.5x |
 | math_problems | mobius_sieve | cython | 134.582 | 55.412 | 2.4x |
 | leetcode | fizzbuzz | cython | 68.246 | 29.196 | 2.3x |
+| string_processing | classify_transitions | cython | 12.844 | 5.836 | 2.2x |
 | string_processing | suffix_array_naive | cython | 11.998 | 5.623 | 2.1x |
 | cryptography | salsa20_quarter | cython | 286.090 | 162.326 | 1.8x |
 | leetcode | two_sum_all_pairs | cython | 13.765 | 8.445 | 1.6x |
@@ -402,25 +412,25 @@ Compares portable Cython (scalar) vs platform-optimized SIMD.
 
 | Kernel | Size | Portable (ms) | SIMD (ms) | SIMD ISA | Speedup |
 |--------|------|--------------|-----------|----------|----------|
-| relu | 5,000,000 | 4.908 | 1.666 | avx2+fma | 2.9x |
-| sigmoid | 2,000,000 | 7.118 | 0.656 | avx2+fma | 10.9x |
-| gelu | 2,000,000 | 13.457 | 13.613 | avx2+fma | 1.0x |
-| silu | 2,000,000 | 6.035 | 6.033 | avx2+fma | 1.0x |
-| softmax | 1,000,000 | 3.719 | 2.954 | avx2+fma | 1.3x |
-| elementwise_add | 5,000,000 | 5.497 | 2.099 | avx2+fma | 2.6x |
-| elementwise_mul | 5,000,000 | 2.026 | 2.118 | avx2+fma | 1.0x |
-| residual_add | 5,000,000 | 2.001 | 2.101 | avx2+fma | 1.0x |
-| gemm | 200x200 | 3.551 | 0.263 | avx2+fma | 13.5x |
-| batch_norm | 5,000,000 | 5.070 | 1.663 | avx2+fma | 3.0x |
-| layer_norm | 1,000,000 | 1.806 | 0.372 | avx2+fma | 4.8x |
-| conv1d | 500,000 | 1.440 | 0.177 | avx2+fma | 8.1x |
-| max_pool_1d | 5,000,000 | 2.354 | 1.476 | avx2+fma | 1.6x |
-| attention_scores | 128x64d | 0.562 | 0.046 | avx2+fma | 12.3x |
-| avg_pool_1d | 5,000,000 | 1.739 | 1.740 | avx2+fma | 1.0x |
-| conv2d | 256x256 | 0.323 | 0.056 | avx2+fma | 5.8x |
-| cross_entropy | 100,000 | 0.371 | 0.368 | avx2+fma | 1.0x |
-| depthwise_conv | 64x10000 | 1.576 | 0.185 | avx2+fma | 8.5x |
-| dropout_mask | 5,000,000 | 5.998 | 3.791 | avx2+fma | 1.6x |
-| embedding_lookup | 10000v,64d,50000n | 1.366 | 0.312 | avx2+fma | 4.4x |
-| global_avg_pool | 256x10000 | 1.137 | 0.377 | avx2+fma | 3.0x |
-| instance_norm | 64x10000 | 0.801 | 0.196 | avx2+fma | 4.1x |
+| relu | 5,000,000 | 4.612 | 1.595 | avx2+fma | 2.9x |
+| sigmoid | 2,000,000 | 7.221 | 0.647 | avx2+fma | 11.2x |
+| gelu | 2,000,000 | 13.490 | 13.418 | avx2+fma | 1.0x |
+| silu | 2,000,000 | 6.035 | 6.034 | avx2+fma | 1.0x |
+| softmax | 1,000,000 | 3.672 | 2.937 | avx2+fma | 1.3x |
+| elementwise_add | 5,000,000 | 5.060 | 2.092 | avx2+fma | 2.4x |
+| elementwise_mul | 5,000,000 | 1.973 | 2.012 | avx2+fma | 1.0x |
+| residual_add | 5,000,000 | 2.103 | 1.910 | avx2+fma | 1.1x |
+| gemm | 200x200 | 3.544 | 0.253 | avx2+fma | 14.0x |
+| batch_norm | 5,000,000 | 4.640 | 1.626 | avx2+fma | 2.9x |
+| layer_norm | 1,000,000 | 1.710 | 0.258 | avx2+fma | 6.6x |
+| conv1d | 500,000 | 1.451 | 0.180 | avx2+fma | 8.0x |
+| max_pool_1d | 5,000,000 | 2.354 | 1.405 | avx2+fma | 1.7x |
+| attention_scores | 128x64d | 0.566 | 0.052 | avx2+fma | 10.8x |
+| avg_pool_1d | 5,000,000 | 1.687 | 1.694 | avx2+fma | 1.0x |
+| conv2d | 256x256 | 0.319 | 0.056 | avx2+fma | 5.7x |
+| cross_entropy | 100,000 | 0.369 | 0.368 | avx2+fma | 1.0x |
+| depthwise_conv | 64x10000 | 1.577 | 0.186 | avx2+fma | 8.5x |
+| dropout_mask | 5,000,000 | 5.895 | 3.779 | avx2+fma | 1.6x |
+| embedding_lookup | 10000v,64d,50000n | 1.360 | 0.337 | avx2+fma | 4.0x |
+| global_avg_pool | 256x10000 | 1.081 | 0.308 | avx2+fma | 3.5x |
+| instance_norm | 64x10000 | 0.794 | 0.183 | avx2+fma | 4.3x |

--- a/cnake_charmer/cy/algorithms/deque_sliding_max.pyx
+++ b/cnake_charmer/cy/algorithms/deque_sliding_max.pyx
@@ -1,0 +1,82 @@
+# cython: boundscheck=False, wraparound=False, cdivision=True, language_level=3
+"""Sliding window maximum using a cdef class monotonic deque (Cython).
+
+Keywords: sliding window, maximum, cdef class, monotonic deque, algorithms, cython, benchmark
+"""
+
+from libc.stdlib cimport malloc, free
+from cnake_charmer.benchmarks import cython_benchmark
+
+
+cdef class IntDeque:
+    """Fixed-capacity deque of ints backed by a C array."""
+    cdef int *data
+    cdef int head
+    cdef int tail
+    cdef int capacity
+
+    def __cinit__(self, int capacity):
+        self.capacity = capacity
+        self.head = 0
+        self.tail = 0
+        self.data = <int *>malloc(capacity * sizeof(int))
+        if not self.data:
+            raise MemoryError()
+
+    def __dealloc__(self):
+        if self.data:
+            free(self.data)
+
+    cdef inline bint empty(self):
+        return self.head == self.tail
+
+    cdef inline int front(self):
+        return self.data[self.head]
+
+    cdef inline int back(self):
+        return self.data[self.tail - 1]
+
+    cdef inline void push_back(self, int val):
+        self.data[self.tail] = val
+        self.tail += 1
+
+    cdef inline void pop_front(self):
+        self.head += 1
+
+    cdef inline void pop_back(self):
+        self.tail -= 1
+
+
+@cython_benchmark(syntax="cy", args=(100000,))
+def deque_sliding_max(int n):
+    """Compute sliding window maximum using a cdef class IntDeque."""
+    cdef int k = 1000
+    cdef int *arr = <int *>malloc(n * sizeof(int))
+    if not arr:
+        raise MemoryError()
+
+    cdef int i
+    cdef long long tmp
+    for i in range(n):
+        tmp = ((<long long>i * <long long>2654435761 + 13) ^ (<long long>i >> 3))
+        arr[i] = <int>(tmp % 1000000)
+
+    cdef IntDeque dq = IntDeque(n)
+    cdef long long max_sum = 0
+
+    for i in range(n):
+        # Remove elements outside window
+        while not dq.empty() and dq.front() <= i - k:
+            dq.pop_front()
+
+        # Remove smaller elements from back
+        while not dq.empty() and arr[dq.back()] <= arr[i]:
+            dq.pop_back()
+
+        dq.push_back(i)
+
+        if i >= k - 1:
+            max_sum += arr[dq.front()]
+
+    free(arr)
+    return max_sum

--- a/cnake_charmer/cy/algorithms/ring_buffer_mean.pyx
+++ b/cnake_charmer/cy/algorithms/ring_buffer_mean.pyx
@@ -1,0 +1,59 @@
+# cython: boundscheck=False, wraparound=False, cdivision=True, language_level=3
+"""Ring buffer running mean computation (Cython with cdef class).
+
+Keywords: ring buffer, circular buffer, running mean, cdef class, extension type, benchmark
+"""
+
+from libc.stdlib cimport malloc, free
+from cnake_charmer.benchmarks import cython_benchmark
+
+
+cdef class RingBuffer:
+    """Fixed-capacity circular buffer with O(1) push and running total."""
+    cdef double *data
+    cdef int capacity
+    cdef int head
+    cdef int size
+    cdef double total
+
+    def __cinit__(self, int capacity):
+        self.capacity = capacity
+        self.head = 0
+        self.size = 0
+        self.total = 0.0
+        self.data = <double *>malloc(capacity * sizeof(double))
+        if not self.data:
+            raise MemoryError()
+        cdef int i
+        for i in range(capacity):
+            self.data[i] = 0.0
+
+    def __dealloc__(self):
+        if self.data:
+            free(self.data)
+
+    cdef double push_and_mean(self, double val):
+        """Push a value and return the current mean."""
+        if self.size == self.capacity:
+            self.total -= self.data[self.head]
+        else:
+            self.size += 1
+        self.data[self.head] = val
+        self.total += val
+        self.head = (self.head + 1) % self.capacity
+        return self.total / self.size
+
+
+@cython_benchmark(syntax="cy", args=(100000,))
+def ring_buffer_mean(int n):
+    """Push n values into a cdef class ring buffer and accumulate running means."""
+    cdef RingBuffer rb = RingBuffer(1000)
+    cdef double mean_sum = 0.0
+    cdef double val
+    cdef int i
+
+    for i in range(n):
+        val = (i * 7 + 13) % 10007 / 100.0
+        mean_sum += rb.push_and_mean(val)
+
+    return mean_sum

--- a/cnake_charmer/cy/algorithms/rpn_eval.pyx
+++ b/cnake_charmer/cy/algorithms/rpn_eval.pyx
@@ -1,0 +1,86 @@
+# cython: boundscheck=False, wraparound=False, cdivision=True, language_level=3
+"""Evaluate RPN expressions (Cython with cdef enum and cdef class Stack).
+
+Keywords: rpn, stack, cdef enum, cdef class, calculator, expression, cython, benchmark
+"""
+
+from libc.stdlib cimport malloc, free
+from libc.math cimport fabs
+from cnake_charmer.benchmarks import cython_benchmark
+
+
+cdef enum OpType:
+    OP_PUSH = 0
+    OP_ADD = 1
+    OP_SUB = 2
+    OP_MUL = 3
+    OP_DIV = 4
+
+
+cdef class DoubleStack:
+    """Fixed-capacity stack of doubles backed by a C array."""
+    cdef double *data
+    cdef int sp
+    cdef int capacity
+
+    def __cinit__(self, int capacity):
+        self.capacity = capacity
+        self.sp = 0
+        self.data = <double *>malloc(capacity * sizeof(double))
+        if not self.data:
+            raise MemoryError()
+
+    def __dealloc__(self):
+        if self.data:
+            free(self.data)
+
+    cdef inline void push(self, double val):
+        self.data[self.sp] = val
+        self.sp += 1
+        if self.sp >= self.capacity:
+            self.sp = 1
+
+    cdef inline double pop(self):
+        self.sp -= 1
+        return self.data[self.sp]
+
+    cdef inline int size(self):
+        return self.sp
+
+
+@cython_benchmark(syntax="cy", args=(100000,))
+def rpn_eval(int n):
+    """Evaluate RPN operations using cdef enum OpType and cdef class DoubleStack."""
+    cdef DoubleStack stack = DoubleStack(1024)
+    cdef double accumulator = 0.0
+    cdef double a, b, result, val
+    cdef int i
+    cdef unsigned int h
+    cdef OpType op
+
+    for i in range(n):
+        h = ((<unsigned long long>i * 2654435761 + 1013904223) >> 8) & 0xFFFF
+
+        if stack.size() < 2 or h % 5 == 0:
+            val = ((<int>((h * 31 + 7) % 200)) - 100) / 10.0
+            stack.push(val)
+        else:
+            op = <OpType>(h % 4 + 1)
+            b = stack.pop()
+            a = stack.pop()
+
+            if op == OP_ADD:
+                result = a + b
+            elif op == OP_SUB:
+                result = a - b
+            elif op == OP_MUL:
+                result = a * b
+            elif op == OP_DIV:
+                result = a / b if fabs(b) > 1e-10 else 0.0
+            else:
+                result = 0.0
+
+            stack.push(result)
+            accumulator += result
+
+    return accumulator

--- a/cnake_charmer/cy/geometry/polygon_area_centroid.pyx
+++ b/cnake_charmer/cy/geometry/polygon_area_centroid.pyx
@@ -1,0 +1,83 @@
+# cython: boundscheck=False, wraparound=False, cdivision=True, language_level=3
+"""Compute polygon area and centroid (Cython with cdef class Vec2D).
+
+Keywords: polygon, area, centroid, cdef class, cpdef, vector, geometry, cython, benchmark
+"""
+
+from libc.math cimport cos, sin, M_PI, fabs
+from libc.stdlib cimport malloc, free
+from cnake_charmer.benchmarks import cython_benchmark
+
+
+cdef class Vec2D:
+    """2D vector with typed attributes and cdef arithmetic methods."""
+    cdef double x
+    cdef double y
+
+    def __cinit__(self, double x, double y):
+        self.x = x
+        self.y = y
+
+    cdef inline void set(self, double x, double y):
+        """Set coordinates without creating a new object."""
+        self.x = x
+        self.y = y
+
+    cdef inline double cross(self, Vec2D other):
+        """Compute 2D cross product (scalar): self.x * other.y - self.y * other.x."""
+        return self.x * other.y - self.y * other.x
+
+    cdef inline double dot(self, Vec2D other):
+        """Compute dot product."""
+        return self.x * other.x + self.y * other.y
+
+    cpdef Vec2D add(self, Vec2D other):
+        """Return a new Vec2D that is the sum of self and other."""
+        return Vec2D(self.x + other.x, self.y + other.y)
+
+
+@cython_benchmark(syntax="cy", args=(100000,))
+def polygon_area_centroid(int n):
+    """Compute polygon area and centroid using cdef class Vec2D."""
+    cdef int i, j
+    cdef double angle, r
+    cdef unsigned long long h
+    cdef double area = 0.0, cx = 0.0, cy = 0.0, cross_val
+
+    # Generate vertices
+    cdef double *xs = <double *>malloc(n * sizeof(double))
+    cdef double *ys = <double *>malloc(n * sizeof(double))
+    if not xs or not ys:
+        if xs: free(xs)
+        if ys: free(ys)
+        raise MemoryError()
+
+    for i in range(n):
+        angle = 2.0 * M_PI * i / n
+        h = ((<unsigned long long>i * 2654435761) >> 8) & 0xFFFF
+        r = 10.0 + (h % 500) / 100.0
+        xs[i] = r * cos(angle)
+        ys[i] = r * sin(angle)
+
+    # Pre-allocate Vec2D objects and reuse via set() to avoid per-iteration allocation
+    cdef Vec2D vi = Vec2D(0.0, 0.0)
+    cdef Vec2D vj = Vec2D(0.0, 0.0)
+
+    for i in range(n):
+        j = (i + 1) % n
+        vi.set(xs[i], ys[i])
+        vj.set(xs[j], ys[j])
+        cross_val = vi.cross(vj)
+        area += cross_val
+        cx += (vi.x + vj.x) * cross_val
+        cy += (vi.y + vj.y) * cross_val
+
+    area *= 0.5
+
+    if fabs(area) > 1e-15:
+        cx /= (6.0 * area)
+        cy /= (6.0 * area)
+
+    free(xs)
+    free(ys)
+    return (area, cx, cy)

--- a/cnake_charmer/cy/image_processing/image_flip_checksum.pyx
+++ b/cnake_charmer/cy/image_processing/image_flip_checksum.pyx
@@ -1,0 +1,57 @@
+# cython: boundscheck=False, wraparound=False, cdivision=True, language_level=3
+"""Flip an image and compute checksum (Cython with typed memoryviews).
+
+Keywords: image, flip, typed memoryview, transform, checksum, image processing, cython, benchmark
+"""
+
+from libc.stdlib cimport malloc, free
+from cnake_charmer.benchmarks import cython_benchmark
+
+
+@cython_benchmark(syntax="cy", args=(500,))
+def image_flip_checksum(int n):
+    """Flip image using typed memoryviews and compute weighted checksum."""
+    cdef int nn = n * n
+    cdef unsigned char *img_ptr = <unsigned char *>malloc(nn * sizeof(unsigned char))
+    cdef unsigned char *flip_ptr = <unsigned char *>malloc(nn * sizeof(unsigned char))
+    cdef unsigned char *res_ptr = <unsigned char *>malloc(nn * sizeof(unsigned char))
+    if not img_ptr or not flip_ptr or not res_ptr:
+        if img_ptr: free(img_ptr)
+        if flip_ptr: free(flip_ptr)
+        if res_ptr: free(res_ptr)
+        raise MemoryError()
+
+    # Create typed memoryviews from raw pointers
+    cdef unsigned char[:] img = <unsigned char[:nn]>img_ptr
+    cdef unsigned char[:] flipped = <unsigned char[:nn]>flip_ptr
+    cdef unsigned char[:] result = <unsigned char[:nn]>res_ptr
+
+    cdef int i, j
+    cdef unsigned long long h
+    cdef long long checksum = 0
+
+    # Generate image
+    for i in range(n):
+        for j in range(n):
+            h = ((<unsigned long long>i * 2654435761 + <unsigned long long>j * 1103515245 + 7) >> 4) & 0xFF
+            img[i * n + j] = <unsigned char>h
+
+    # Horizontal flip using memoryview access
+    for i in range(n):
+        for j in range(n):
+            flipped[i * n + j] = img[i * n + (n - 1 - j)]
+
+    # Vertical flip using memoryview access
+    for i in range(n):
+        for j in range(n):
+            result[i * n + j] = flipped[(n - 1 - i) * n + j]
+
+    # Weighted checksum
+    for i in range(nn):
+        checksum += <long long>result[i] * ((i % 256) + 1)
+        checksum = checksum & 0x7FFFFFFF
+
+    free(img_ptr)
+    free(flip_ptr)
+    free(res_ptr)
+    return checksum

--- a/cnake_charmer/cy/numerical/matrix_power_trace.pyx
+++ b/cnake_charmer/cy/numerical/matrix_power_trace.pyx
@@ -1,0 +1,68 @@
+# cython: boundscheck=False, wraparound=False, cdivision=True, language_level=3
+"""Compute trace of matrix power (Cython with typed memoryviews).
+
+Keywords: matrix, power, trace, typed memoryview, linear algebra, cython, benchmark
+"""
+
+from libc.stdlib cimport malloc, free
+from cnake_charmer.benchmarks import cython_benchmark
+
+
+cdef void mat_mul(double[:] X, double[:] Y, double[:] R, int size):
+    """Multiply two matrices stored as 1D memoryviews in row-major order."""
+    cdef int i, j, k
+    cdef double x_ik
+
+    for i in range(size * size):
+        R[i] = 0.0
+
+    for i in range(size):
+        for k in range(size):
+            x_ik = X[i * size + k]
+            if x_ik == 0.0:
+                continue
+            for j in range(size):
+                R[i * size + j] += x_ik * Y[k * size + j]
+
+
+@cython_benchmark(syntax="cy", args=(150,))
+def matrix_power_trace(int n):
+    """Compute trace(A^4) using typed memoryviews for matrix storage."""
+    cdef int nn = n * n
+    cdef double *a_ptr = <double *>malloc(nn * sizeof(double))
+    cdef double *a2_ptr = <double *>malloc(nn * sizeof(double))
+    cdef double *a4_ptr = <double *>malloc(nn * sizeof(double))
+    if not a_ptr or not a2_ptr or not a4_ptr:
+        if a_ptr: free(a_ptr)
+        if a2_ptr: free(a2_ptr)
+        if a4_ptr: free(a4_ptr)
+        raise MemoryError()
+
+    # Create typed memoryviews from raw pointers
+    cdef double[:] A = <double[:nn]>a_ptr
+    cdef double[:] A2 = <double[:nn]>a2_ptr
+    cdef double[:] A4 = <double[:nn]>a4_ptr
+
+    cdef int i, j
+    cdef unsigned long long h
+    cdef double trace
+
+    # Generate matrix
+    for i in range(n):
+        for j in range(n):
+            h = ((<unsigned long long>i * 2654435761 + <unsigned long long>j * 1103515245) >> 12) & 0xFFF
+            A[i * n + j] = (<int>(h % 201) - 100) / 100.0
+
+    # Compute A^4 = (A*A) * (A*A)
+    mat_mul(A, A, A2, n)
+    mat_mul(A2, A2, A4, n)
+
+    # Trace
+    trace = 0.0
+    for i in range(n):
+        trace += A4[i * n + i]
+
+    free(a_ptr)
+    free(a2_ptr)
+    free(a4_ptr)
+    return trace

--- a/cnake_charmer/cy/numerical/memview_weighted_sum.pyx
+++ b/cnake_charmer/cy/numerical/memview_weighted_sum.pyx
@@ -1,0 +1,44 @@
+# cython: boundscheck=False, wraparound=False, cdivision=True, language_level=3
+"""Weighted prefix sum with exponential decay (Cython with typed memoryviews).
+
+Keywords: weighted sum, prefix sum, typed memoryview, exponential decay, cython, benchmark
+"""
+
+from libc.stdlib cimport malloc, free
+from cnake_charmer.benchmarks import cython_benchmark
+
+
+@cython_benchmark(syntax="cy", args=(100000,))
+def memview_weighted_sum(int n):
+    """Compute weighted prefix sums using typed memoryviews."""
+    cdef double *val_ptr = <double *>malloc(n * sizeof(double))
+    cdef double *res_ptr = <double *>malloc(n * sizeof(double))
+    if not val_ptr or not res_ptr:
+        if val_ptr: free(val_ptr)
+        if res_ptr: free(res_ptr)
+        raise MemoryError()
+
+    # Create typed memoryviews from raw pointers
+    cdef double[:] values = <double[:n]>val_ptr
+    cdef double[:] result = <double[:n]>res_ptr
+
+    cdef double decay = 0.999
+    cdef int i
+    cdef double total = 0.0
+    cdef long long htmp
+
+    for i in range(n):
+        htmp = (<long long>i * <long long>2654435761) % 1000
+        values[i] = htmp / 100.0
+
+    # Compute using recurrence with memoryview access
+    result[0] = values[0]
+    for i in range(1, n):
+        result[i] = values[i] + decay * result[i - 1]
+
+    for i in range(n):
+        total += result[i]
+
+    free(val_ptr)
+    free(res_ptr)
+    return total

--- a/cnake_charmer/cy/simulation/particle_bounce.pyx
+++ b/cnake_charmer/cy/simulation/particle_bounce.pyx
@@ -1,0 +1,85 @@
+# cython: boundscheck=False, wraparound=False, cdivision=True, language_level=3
+"""Simulate particles bouncing in a box (Cython with cdef class and @property).
+
+Keywords: particle, simulation, cdef class, property, bounce, physics, cython, benchmark
+"""
+
+from cnake_charmer.benchmarks import cython_benchmark
+
+
+cdef class Particle:
+    """A particle with position, velocity, and mass using typed C attributes."""
+    cdef public double x, y, vx, vy, mass
+
+    def __cinit__(self, double x, double y, double vx, double vy, double mass):
+        self.x = x
+        self.y = y
+        self.vx = vx
+        self.vy = vy
+        self.mass = mass
+
+    @property
+    def kinetic_energy(self):
+        """Compute kinetic energy: 0.5 * mass * v^2."""
+        return 0.5 * self.mass * (self.vx * self.vx + self.vy * self.vy)
+
+    @property
+    def speed_squared(self):
+        """Compute speed squared: vx^2 + vy^2."""
+        return self.vx * self.vx + self.vy * self.vy
+
+    cdef void step(self, double dt):
+        """Advance the particle by dt and bounce off [0,1] walls."""
+        self.x += self.vx * dt
+        self.y += self.vy * dt
+
+        if self.x < 0.0:
+            self.x = -self.x
+            self.vx = -self.vx
+        elif self.x > 1.0:
+            self.x = 2.0 - self.x
+            self.vx = -self.vx
+
+        if self.y < 0.0:
+            self.y = -self.y
+            self.vy = -self.vy
+        elif self.y > 1.0:
+            self.y = 2.0 - self.y
+            self.vy = -self.vy
+
+
+@cython_benchmark(syntax="cy", args=(5000,))
+def particle_bounce(int n):
+    """Simulate n particles bouncing in a box using cdef class with @property."""
+    cdef int steps = 200
+    cdef double dt = 0.01
+    cdef int i, s
+    cdef double total_ke = 0.0
+    cdef unsigned long long h
+    cdef double px, py, pvx, pvy, m
+
+    # Create particle list
+    particles = []
+    for i in range(n):
+        h = (<unsigned long long>i * 2654435761) & 0xFFFFFFFF
+        px = (h % 1000) / 1000.0
+        h = (h * 6364136223846793005 + 1) & 0xFFFFFFFF
+        py = (h % 1000) / 1000.0
+        h = (h * 6364136223846793005 + 1) & 0xFFFFFFFF
+        pvx = ((<long long>(h % 2001)) - 1000) / 100.0
+        h = (h * 6364136223846793005 + 1) & 0xFFFFFFFF
+        pvy = ((<long long>(h % 2001)) - 1000) / 100.0
+        m = 1.0 + (i % 5) * 0.5
+        particles.append(Particle(px, py, pvx, pvy, m))
+
+    cdef Particle p
+    for s in range(steps):
+        for i in range(n):
+            p = <Particle>particles[i]
+            p.step(dt)
+
+    for i in range(n):
+        p = <Particle>particles[i]
+        total_ke += p.kinetic_energy
+
+    return total_ke

--- a/cnake_charmer/cy/sorting/heap_kth_smallest.pyx
+++ b/cnake_charmer/cy/sorting/heap_kth_smallest.pyx
@@ -1,0 +1,100 @@
+# cython: boundscheck=False, wraparound=False, cdivision=True, language_level=3
+"""Find kth smallest element using a cdef class max-heap (Cython).
+
+Keywords: heap, kth smallest, cdef class, cdef inline, max-heap, sorting, cython, benchmark
+"""
+
+from libc.stdlib cimport malloc, free
+from cnake_charmer.benchmarks import cython_benchmark
+
+
+cdef class MaxHeap:
+    """Max-heap with fixed capacity, using cdef inline methods."""
+    cdef long long *data
+    cdef int size
+    cdef int capacity
+
+    def __cinit__(self, int capacity):
+        self.capacity = capacity
+        self.size = 0
+        self.data = <long long *>malloc(capacity * sizeof(long long))
+        if not self.data:
+            raise MemoryError()
+
+    def __dealloc__(self):
+        if self.data:
+            free(self.data)
+
+    cdef inline void push(self, long long val):
+        """Push a value onto the heap."""
+        self.data[self.size] = val
+        self.size += 1
+        self._sift_up(self.size - 1)
+
+    cdef inline long long peek(self):
+        """Return the maximum value without removing it."""
+        return self.data[0]
+
+    cdef inline void replace_top(self, long long val):
+        """Replace the top (max) element and restore heap property."""
+        self.data[0] = val
+        self._sift_down(0)
+
+    cdef void _sift_up(self, int pos) noexcept:
+        cdef int parent
+        cdef long long tmp
+        cdef long long *d = self.data
+        while pos > 0:
+            parent = (pos - 1) >> 1
+            if d[pos] > d[parent]:
+                tmp = d[pos]
+                d[pos] = d[parent]
+                d[parent] = tmp
+                pos = parent
+            else:
+                break
+
+    cdef void _sift_down(self, int pos) noexcept:
+        cdef int left, right, largest
+        cdef long long tmp
+        cdef long long *d = self.data
+        cdef int sz = self.size
+        while True:
+            left = 2 * pos + 1
+            right = 2 * pos + 2
+            largest = pos
+            if left < sz and d[left] > d[largest]:
+                largest = left
+            if right < sz and d[right] > d[largest]:
+                largest = right
+            if largest != pos:
+                tmp = d[pos]
+                d[pos] = d[largest]
+                d[largest] = tmp
+                pos = largest
+            else:
+                break
+
+
+@cython_benchmark(syntax="cy", args=(100000,))
+def heap_kth_smallest(int n):
+    """Stream n values through a cdef class MaxHeap to find kth smallest."""
+    cdef int k = 100
+    cdef MaxHeap heap = MaxHeap(k)
+    cdef long long result_sum = 0
+    cdef long long val
+    cdef int i
+
+    for i in range(n):
+        val = ((<long long>i * <long long>2654435761 + 17) ^ (<long long>i * <long long>1103515245)) % 1000000
+
+        if heap.size < k:
+            heap.push(val)
+            if heap.size == k:
+                result_sum += heap.peek()
+        else:
+            if val < heap.peek():
+                heap.replace_top(val)
+            result_sum += heap.peek()
+
+    return result_sum

--- a/cnake_charmer/cy/string_processing/classify_transitions.pyx
+++ b/cnake_charmer/cy/string_processing/classify_transitions.pyx
@@ -1,0 +1,54 @@
+# cython: boundscheck=False, wraparound=False, cdivision=True, language_level=3
+"""Count character class transitions using cdef enum (Cython).
+
+Keywords: character classification, cdef enum, state machine, transitions, cython, benchmark
+"""
+
+from cnake_charmer.benchmarks import cython_benchmark
+
+
+cdef enum CharClass:
+    UPPER = 0
+    LOWER = 1
+    DIGIT = 2
+    SPACE = 3
+    PUNCT = 4
+    OTHER = 5
+
+
+cdef inline CharClass classify_char(int h) noexcept nogil:
+    """Classify a character code into a CharClass enum value."""
+    if 65 <= h <= 90:
+        return UPPER
+    elif 97 <= h <= 122:
+        return LOWER
+    elif 48 <= h <= 57:
+        return DIGIT
+    elif h == 32 or h == 9 or h == 10:
+        return SPACE
+    elif h == 33 or h == 44 or h == 46 or h == 59 or h == 58 or h == 63 or h == 45:
+        return PUNCT
+    else:
+        return OTHER
+
+
+@cython_benchmark(syntax="cy", args=(100000,))
+def classify_transitions(int n):
+    """Classify chars using cdef enum and count class transitions."""
+    cdef int transitions = 0
+    cdef CharClass prev_class
+    cdef CharClass cur_class
+    cdef int i
+    cdef long long h
+    cdef bint has_prev = False
+
+    for i in range(n):
+        h = (((<long long>i * 6364136223846793005 + 1442695040888963407) >> 16) & 0x7F)
+        cur_class = classify_char(<int>h)
+
+        if has_prev and cur_class != prev_class:
+            transitions += 1
+        prev_class = cur_class
+        has_prev = True
+
+    return transitions

--- a/cnake_charmer/py/algorithms/deque_sliding_max.py
+++ b/cnake_charmer/py/algorithms/deque_sliding_max.py
@@ -1,0 +1,49 @@
+"""Sliding window maximum using a monotonic deque.
+
+Keywords: sliding window, maximum, monotonic deque, data structure, algorithms, benchmark
+"""
+
+from cnake_charmer.benchmarks import python_benchmark
+
+
+@python_benchmark(args=(100000,))
+def deque_sliding_max(n: int) -> int:
+    """Compute sliding window maximum over an array of n values with window size 1000.
+
+    Uses a monotonic deque to maintain the window maximum in amortized O(1) per element.
+    Returns the sum of all window maxima.
+
+    Args:
+        n: Array length.
+
+    Returns:
+        Sum of all sliding window maxima.
+    """
+    k = 1000
+    # Generate array
+    arr = [0] * n
+    for i in range(n):
+        arr[i] = ((i * 2654435761 + 13) ^ (i >> 3)) % 1000000
+
+    # Monotonic deque (stores indices)
+    deque = [0] * n
+    head = 0
+    tail = 0
+    max_sum = 0
+
+    for i in range(n):
+        # Remove elements outside window
+        while head < tail and deque[head] <= i - k:
+            head += 1
+
+        # Remove smaller elements from back
+        while head < tail and arr[deque[tail - 1]] <= arr[i]:
+            tail -= 1
+
+        deque[tail] = i
+        tail += 1
+
+        if i >= k - 1:
+            max_sum += arr[deque[head]]
+
+    return max_sum

--- a/cnake_charmer/py/algorithms/ring_buffer_mean.py
+++ b/cnake_charmer/py/algorithms/ring_buffer_mean.py
@@ -1,0 +1,40 @@
+"""Ring buffer running mean computation.
+
+Keywords: ring buffer, circular buffer, running mean, data structure, benchmark
+"""
+
+from cnake_charmer.benchmarks import python_benchmark
+
+
+@python_benchmark(args=(100000,))
+def ring_buffer_mean(n: int) -> float:
+    """Push n values into a fixed-size ring buffer and accumulate running means.
+
+    Each value is pushed into a ring buffer of capacity 1000. After each push,
+    the mean of the buffer contents is added to a running sum.
+
+    Args:
+        n: Number of values to push.
+
+    Returns:
+        Sum of all running means.
+    """
+    capacity = 1000
+    buf = [0.0] * capacity
+    head = 0
+    size = 0
+    total = 0.0
+    mean_sum = 0.0
+
+    for i in range(n):
+        val = (i * 7 + 13) % 10007 / 100.0
+        if size == capacity:
+            total -= buf[head]
+        else:
+            size += 1
+        buf[head] = val
+        total += val
+        head = (head + 1) % capacity
+        mean_sum += total / size
+
+    return mean_sum

--- a/cnake_charmer/py/algorithms/rpn_eval.py
+++ b/cnake_charmer/py/algorithms/rpn_eval.py
@@ -1,0 +1,63 @@
+"""Evaluate reverse Polish notation expressions.
+
+Keywords: rpn, stack, calculator, expression evaluation, algorithms, benchmark
+"""
+
+from cnake_charmer.benchmarks import python_benchmark
+
+
+@python_benchmark(args=(100000,))
+def rpn_eval(n: int) -> float:
+    """Generate and evaluate n RPN operations, returning the final accumulator.
+
+    Generates a deterministic stream of operands and operators (+, -, *, /),
+    evaluates them using a stack-based RPN interpreter, and accumulates results.
+
+    Args:
+        n: Number of RPN operations to evaluate.
+
+    Returns:
+        Sum of all expression results.
+    """
+    # Token types
+    OP_ADD = 1
+    OP_SUB = 2
+    OP_MUL = 3
+    OP_DIV = 4
+
+    stack = [0.0] * 1024
+    sp = 0  # stack pointer
+    accumulator = 0.0
+
+    for i in range(n):
+        h = ((i * 2654435761 + 1013904223) >> 8) & 0xFFFF
+
+        if sp < 2 or h % 5 == 0:
+            # Push a value
+            val = ((h * 31 + 7) % 200 - 100) / 10.0
+            stack[sp] = val
+            sp += 1
+            if sp >= 1024:
+                sp = 1
+        else:
+            op = h % 4 + 1  # 1-4
+            b = stack[sp - 1]
+            a = stack[sp - 2]
+            sp -= 2
+
+            if op == OP_ADD:
+                result = a + b
+            elif op == OP_SUB:
+                result = a - b
+            elif op == OP_MUL:
+                result = a * b
+            elif op == OP_DIV:
+                result = a / b if abs(b) > 1e-10 else 0.0
+            else:
+                result = 0.0
+
+            stack[sp] = result
+            sp += 1
+            accumulator += result
+
+    return accumulator

--- a/cnake_charmer/py/geometry/polygon_area_centroid.py
+++ b/cnake_charmer/py/geometry/polygon_area_centroid.py
@@ -1,0 +1,55 @@
+"""Compute polygon area and centroid using the shoelace formula.
+
+Keywords: polygon, area, centroid, shoelace, geometry, benchmark
+"""
+
+from cnake_charmer.benchmarks import python_benchmark
+
+
+@python_benchmark(args=(100000,))
+def polygon_area_centroid(n: int) -> tuple:
+    """Generate an n-vertex polygon and compute its signed area and centroid.
+
+    Vertices are placed on a distorted circle to form a non-self-intersecting
+    polygon. Uses the shoelace formula for area and centroid computation.
+
+    Args:
+        n: Number of polygon vertices.
+
+    Returns:
+        Tuple of (area, centroid_x, centroid_y).
+    """
+    import math
+
+    # Generate polygon vertices on a distorted circle
+    xs = [0.0] * n
+    ys = [0.0] * n
+    for i in range(n):
+        angle = 2.0 * math.pi * i / n
+        # Deterministic radius perturbation
+        h = ((i * 2654435761) >> 8) & 0xFFFF
+        r = 10.0 + (h % 500) / 100.0
+        xs[i] = r * math.cos(angle)
+        ys[i] = r * math.sin(angle)
+
+    # Shoelace formula for signed area
+    area = 0.0
+    for i in range(n):
+        j = (i + 1) % n
+        area += xs[i] * ys[j] - xs[j] * ys[i]
+    area *= 0.5
+
+    # Centroid
+    cx = 0.0
+    cy = 0.0
+    for i in range(n):
+        j = (i + 1) % n
+        cross = xs[i] * ys[j] - xs[j] * ys[i]
+        cx += (xs[i] + xs[j]) * cross
+        cy += (ys[i] + ys[j]) * cross
+
+    if abs(area) > 1e-15:
+        cx /= 6.0 * area
+        cy /= 6.0 * area
+
+    return (area, cx, cy)

--- a/cnake_charmer/py/image_processing/image_flip_checksum.py
+++ b/cnake_charmer/py/image_processing/image_flip_checksum.py
@@ -1,0 +1,45 @@
+"""Flip an image horizontally and vertically, compute checksum.
+
+Keywords: image, flip, transform, checksum, image processing, benchmark
+"""
+
+from cnake_charmer.benchmarks import python_benchmark
+
+
+@python_benchmark(args=(500,))
+def image_flip_checksum(n: int) -> int:
+    """Generate an n x n grayscale image, flip it horizontally then vertically,
+    and compute a weighted checksum.
+
+    Args:
+        n: Image dimension (n x n pixels).
+
+    Returns:
+        Weighted checksum of the double-flipped image.
+    """
+    # Generate image (flat row-major)
+    img = [0] * (n * n)
+    for i in range(n):
+        for j in range(n):
+            h = ((i * 2654435761 + j * 1103515245 + 7) >> 4) & 0xFF
+            img[i * n + j] = h
+
+    # Horizontal flip (mirror left-right)
+    flipped = [0] * (n * n)
+    for i in range(n):
+        for j in range(n):
+            flipped[i * n + j] = img[i * n + (n - 1 - j)]
+
+    # Vertical flip (mirror top-bottom)
+    result = [0] * (n * n)
+    for i in range(n):
+        for j in range(n):
+            result[i * n + j] = flipped[(n - 1 - i) * n + j]
+
+    # Weighted checksum
+    checksum = 0
+    for i in range(n * n):
+        checksum += result[i] * ((i % 256) + 1)
+        checksum &= 0x7FFFFFFF
+
+    return checksum

--- a/cnake_charmer/py/numerical/matrix_power_trace.py
+++ b/cnake_charmer/py/numerical/matrix_power_trace.py
@@ -1,0 +1,50 @@
+"""Compute trace of a matrix raised to a power.
+
+Keywords: matrix, power, trace, linear algebra, numerical, benchmark
+"""
+
+from cnake_charmer.benchmarks import python_benchmark
+
+
+@python_benchmark(args=(150,))
+def matrix_power_trace(n: int) -> float:
+    """Compute trace(A^4) for an n x n matrix using repeated matrix multiplication.
+
+    Generates a deterministic matrix A, computes A^4 = A*A*A*A, and returns
+    the trace (sum of diagonal elements).
+
+    Args:
+        n: Matrix dimension (n x n).
+
+    Returns:
+        Trace of A^4.
+    """
+    # Generate matrix A (flat layout, row-major)
+    A = [0.0] * (n * n)
+    for i in range(n):
+        for j in range(n):
+            h = ((i * 2654435761 + j * 1103515245) >> 12) & 0xFFF
+            A[i * n + j] = (h % 201 - 100) / 100.0
+
+    def mat_mul(X, Y, size):
+        R = [0.0] * (size * size)
+        for i in range(size):
+            for k in range(size):
+                x_ik = X[i * size + k]
+                if x_ik == 0.0:
+                    continue
+                for j in range(size):
+                    R[i * size + j] += x_ik * Y[k * size + j]
+            pass
+        return R
+
+    # Compute A^4 = ((A*A)*(A*A))
+    A2 = mat_mul(A, A, n)
+    A4 = mat_mul(A2, A2, n)
+
+    # Trace
+    trace = 0.0
+    for i in range(n):
+        trace += A4[i * n + i]
+
+    return trace

--- a/cnake_charmer/py/numerical/memview_weighted_sum.py
+++ b/cnake_charmer/py/numerical/memview_weighted_sum.py
@@ -1,0 +1,38 @@
+"""Weighted prefix sum with exponential decay.
+
+Keywords: weighted sum, prefix sum, exponential decay, numerical, benchmark
+"""
+
+from cnake_charmer.benchmarks import python_benchmark
+
+
+@python_benchmark(args=(100000,))
+def memview_weighted_sum(n: int) -> float:
+    """Compute a weighted prefix sum where weights decay exponentially.
+
+    For each position i, computes sum of values[j] * decay^(i-j) for j <= i.
+    Returns the sum of all prefix sums.
+
+    Args:
+        n: Array length.
+
+    Returns:
+        Sum of all weighted prefix sums.
+    """
+    decay = 0.999
+    values = [0.0] * n
+    result = [0.0] * n
+
+    for i in range(n):
+        values[i] = ((i * 2654435761) % 1000) / 100.0
+
+    # Compute using recurrence: result[i] = values[i] + decay * result[i-1]
+    result[0] = values[0]
+    for i in range(1, n):
+        result[i] = values[i] + decay * result[i - 1]
+
+    total = 0.0
+    for i in range(n):
+        total += result[i]
+
+    return total

--- a/cnake_charmer/py/simulation/particle_bounce.py
+++ b/cnake_charmer/py/simulation/particle_bounce.py
@@ -1,0 +1,67 @@
+"""Simulate particles bouncing in a box and compute final kinetic energy.
+
+Keywords: particle, simulation, bounce, collision, physics, benchmark
+"""
+
+from cnake_charmer.benchmarks import python_benchmark
+
+
+@python_benchmark(args=(5000,))
+def particle_bounce(n: int) -> float:
+    """Simulate n particles bouncing inside a unit box for 200 steps.
+
+    Each particle has position (x, y) and velocity (vx, vy). Particles bounce
+    off walls elastically. Returns total kinetic energy (sum of v^2) at the end.
+
+    Args:
+        n: Number of particles.
+
+    Returns:
+        Total kinetic energy after simulation.
+    """
+    steps = 200
+    dt = 0.01
+
+    # Initialize particles
+    px = [0.0] * n
+    py = [0.0] * n
+    vx = [0.0] * n
+    vy = [0.0] * n
+    mass = [0.0] * n
+
+    for i in range(n):
+        h = (i * 2654435761) & 0xFFFFFFFF
+        px[i] = (h % 1000) / 1000.0
+        h = (h * 6364136223846793005 + 1) & 0xFFFFFFFF
+        py[i] = (h % 1000) / 1000.0
+        h = (h * 6364136223846793005 + 1) & 0xFFFFFFFF
+        vx[i] = ((h % 2001) - 1000) / 100.0
+        h = (h * 6364136223846793005 + 1) & 0xFFFFFFFF
+        vy[i] = ((h % 2001) - 1000) / 100.0
+        mass[i] = 1.0 + (i % 5) * 0.5
+
+    for _ in range(steps):
+        for i in range(n):
+            px[i] += vx[i] * dt
+            py[i] += vy[i] * dt
+
+            # Bounce off walls [0, 1]
+            if px[i] < 0.0:
+                px[i] = -px[i]
+                vx[i] = -vx[i]
+            elif px[i] > 1.0:
+                px[i] = 2.0 - px[i]
+                vx[i] = -vx[i]
+
+            if py[i] < 0.0:
+                py[i] = -py[i]
+                vy[i] = -vy[i]
+            elif py[i] > 1.0:
+                py[i] = 2.0 - py[i]
+                vy[i] = -vy[i]
+
+    total_ke = 0.0
+    for i in range(n):
+        total_ke += 0.5 * mass[i] * (vx[i] * vx[i] + vy[i] * vy[i])
+
+    return total_ke

--- a/cnake_charmer/py/sorting/heap_kth_smallest.py
+++ b/cnake_charmer/py/sorting/heap_kth_smallest.py
@@ -1,0 +1,71 @@
+"""Find kth smallest element using a max-heap of size k.
+
+Keywords: heap, kth smallest, selection, max-heap, sorting, benchmark
+"""
+
+from cnake_charmer.benchmarks import python_benchmark
+
+
+@python_benchmark(args=(100000,))
+def heap_kth_smallest(n: int) -> int:
+    """Stream n values through a max-heap of size k=100 to find kth smallest.
+
+    Maintains a max-heap of the k smallest values seen so far.
+    Returns the sum of the kth-smallest value after each of the last n-k insertions.
+
+    Args:
+        n: Number of values to stream.
+
+    Returns:
+        Sum of kth-smallest snapshots.
+    """
+    k = 100
+
+    # Max-heap implemented with negation on a min-heap structure
+    heap = []
+    heap_size = 0
+    result_sum = 0
+
+    for i in range(n):
+        val = ((i * 2654435761 + 17) ^ (i * 1103515245)) % 1000000
+
+        if heap_size < k:
+            # Insert into heap (max-heap via negation)
+            heap.append(-val)
+            heap_size += 1
+            _sift_up(heap, heap_size - 1)
+            if heap_size == k:
+                result_sum += -heap[0]
+        else:
+            if val < -heap[0]:
+                heap[0] = -val
+                _sift_down(heap, 0, heap_size)
+            result_sum += -heap[0]
+
+    return result_sum
+
+
+def _sift_up(heap, pos):
+    while pos > 0:
+        parent = (pos - 1) >> 1
+        if heap[pos] < heap[parent]:
+            heap[pos], heap[parent] = heap[parent], heap[pos]
+            pos = parent
+        else:
+            break
+
+
+def _sift_down(heap, pos, size):
+    while True:
+        left = 2 * pos + 1
+        right = 2 * pos + 2
+        smallest = pos
+        if left < size and heap[left] < heap[smallest]:
+            smallest = left
+        if right < size and heap[right] < heap[smallest]:
+            smallest = right
+        if smallest != pos:
+            heap[pos], heap[smallest] = heap[smallest], heap[pos]
+            pos = smallest
+        else:
+            break

--- a/cnake_charmer/py/string_processing/classify_transitions.py
+++ b/cnake_charmer/py/string_processing/classify_transitions.py
@@ -1,0 +1,53 @@
+"""Count character class transitions in generated text.
+
+Keywords: character classification, state machine, transitions, string processing, benchmark
+"""
+
+from cnake_charmer.benchmarks import python_benchmark
+
+
+@python_benchmark(args=(100000,))
+def classify_transitions(n: int) -> int:
+    """Classify characters and count transitions between character classes.
+
+    Generates a deterministic string of length n, classifies each character
+    into one of six classes (UPPER, LOWER, DIGIT, SPACE, PUNCT, OTHER),
+    and counts the number of times the class changes between consecutive chars.
+
+    Args:
+        n: Length of generated string.
+
+    Returns:
+        Number of class transitions.
+    """
+    UPPER = 0
+    LOWER = 1
+    DIGIT = 2
+    SPACE = 3
+    PUNCT = 4
+    OTHER = 5
+
+    transitions = 0
+    prev_class = -1
+
+    for i in range(n):
+        # Deterministic char generation using LCG
+        h = ((i * 6364136223846793005 + 1442695040888963407) >> 16) & 0x7F
+        if 65 <= h <= 90:
+            cur_class = UPPER
+        elif 97 <= h <= 122:
+            cur_class = LOWER
+        elif 48 <= h <= 57:
+            cur_class = DIGIT
+        elif h == 32 or h == 9 or h == 10:
+            cur_class = SPACE
+        elif h in (33, 44, 46, 59, 58, 63, 45):
+            cur_class = PUNCT
+        else:
+            cur_class = OTHER
+
+        if prev_class >= 0 and cur_class != prev_class:
+            transitions += 1
+        prev_class = cur_class
+
+    return transitions

--- a/tests/algorithms/test_deque_sliding_max.py
+++ b/tests/algorithms/test_deque_sliding_max.py
@@ -1,0 +1,11 @@
+"""Test deque_sliding_max equivalence."""
+
+import pytest
+
+from cnake_charmer.cy.algorithms.deque_sliding_max import deque_sliding_max as cy_func
+from cnake_charmer.py.algorithms.deque_sliding_max import deque_sliding_max as py_func
+
+
+@pytest.mark.parametrize("n", [100, 1000, 5000, 10000])
+def test_deque_sliding_max_equivalence(n):
+    assert py_func(n) == cy_func(n)

--- a/tests/algorithms/test_ring_buffer_mean.py
+++ b/tests/algorithms/test_ring_buffer_mean.py
@@ -1,0 +1,13 @@
+"""Test ring_buffer_mean equivalence."""
+
+import pytest
+
+from cnake_charmer.cy.algorithms.ring_buffer_mean import ring_buffer_mean as cy_func
+from cnake_charmer.py.algorithms.ring_buffer_mean import ring_buffer_mean as py_func
+
+
+@pytest.mark.parametrize("n", [10, 100, 1000, 10000])
+def test_ring_buffer_mean_equivalence(n):
+    py_result = py_func(n)
+    cy_result = cy_func(n)
+    assert abs(py_result - cy_result) < 1e-3, f"Mismatch: py={py_result}, cy={cy_result}"

--- a/tests/algorithms/test_rpn_eval.py
+++ b/tests/algorithms/test_rpn_eval.py
@@ -1,0 +1,15 @@
+"""Test rpn_eval equivalence."""
+
+import pytest
+
+from cnake_charmer.cy.algorithms.rpn_eval import rpn_eval as cy_func
+from cnake_charmer.py.algorithms.rpn_eval import rpn_eval as py_func
+
+
+@pytest.mark.parametrize("n", [100, 1000, 5000, 10000])
+def test_rpn_eval_equivalence(n):
+    py_result = py_func(n)
+    cy_result = cy_func(n)
+    assert abs(py_result - cy_result) < max(1e-3, abs(py_result) * 1e-6), (
+        f"Mismatch: py={py_result}, cy={cy_result}"
+    )

--- a/tests/geometry/test_polygon_area_centroid.py
+++ b/tests/geometry/test_polygon_area_centroid.py
@@ -1,0 +1,16 @@
+"""Test polygon_area_centroid equivalence."""
+
+import pytest
+
+from cnake_charmer.cy.geometry.polygon_area_centroid import polygon_area_centroid as cy_func
+from cnake_charmer.py.geometry.polygon_area_centroid import polygon_area_centroid as py_func
+
+
+@pytest.mark.parametrize("n", [10, 100, 1000, 5000])
+def test_polygon_area_centroid_equivalence(n):
+    py_area, py_cx, py_cy = py_func(n)
+    cy_area, cy_cx, cy_cy = cy_func(n)
+    tol = max(1e-3, abs(py_area) * 1e-9)
+    assert abs(py_area - cy_area) < tol, f"Area mismatch: py={py_area}, cy={cy_area}"
+    assert abs(py_cx - cy_cx) < 1e-3, f"Centroid X mismatch: py={py_cx}, cy={cy_cx}"
+    assert abs(py_cy - cy_cy) < 1e-3, f"Centroid Y mismatch: py={py_cy}, cy={cy_cy}"

--- a/tests/image_processing/test_image_flip_checksum.py
+++ b/tests/image_processing/test_image_flip_checksum.py
@@ -1,0 +1,11 @@
+"""Test image_flip_checksum equivalence."""
+
+import pytest
+
+from cnake_charmer.cy.image_processing.image_flip_checksum import image_flip_checksum as cy_func
+from cnake_charmer.py.image_processing.image_flip_checksum import image_flip_checksum as py_func
+
+
+@pytest.mark.parametrize("n", [10, 50, 100, 200])
+def test_image_flip_checksum_equivalence(n):
+    assert py_func(n) == cy_func(n)

--- a/tests/numerical/test_matrix_power_trace.py
+++ b/tests/numerical/test_matrix_power_trace.py
@@ -1,0 +1,14 @@
+"""Test matrix_power_trace equivalence."""
+
+import pytest
+
+from cnake_charmer.cy.numerical.matrix_power_trace import matrix_power_trace as cy_func
+from cnake_charmer.py.numerical.matrix_power_trace import matrix_power_trace as py_func
+
+
+@pytest.mark.parametrize("n", [5, 10, 30, 50])
+def test_matrix_power_trace_equivalence(n):
+    py_result = py_func(n)
+    cy_result = cy_func(n)
+    tol = max(1e-3, abs(py_result) * 1e-6)
+    assert abs(py_result - cy_result) < tol, f"Mismatch: py={py_result}, cy={cy_result}"

--- a/tests/numerical/test_memview_weighted_sum.py
+++ b/tests/numerical/test_memview_weighted_sum.py
@@ -1,0 +1,15 @@
+"""Test memview_weighted_sum equivalence."""
+
+import pytest
+
+from cnake_charmer.cy.numerical.memview_weighted_sum import memview_weighted_sum as cy_func
+from cnake_charmer.py.numerical.memview_weighted_sum import memview_weighted_sum as py_func
+
+
+@pytest.mark.parametrize("n", [10, 100, 1000, 10000])
+def test_memview_weighted_sum_equivalence(n):
+    py_result = py_func(n)
+    cy_result = cy_func(n)
+    assert abs(py_result - cy_result) < max(1e-3, abs(py_result) * 1e-9), (
+        f"Mismatch: py={py_result}, cy={cy_result}"
+    )

--- a/tests/simulation/test_particle_bounce.py
+++ b/tests/simulation/test_particle_bounce.py
@@ -1,0 +1,15 @@
+"""Test particle_bounce equivalence."""
+
+import pytest
+
+from cnake_charmer.cy.simulation.particle_bounce import particle_bounce as cy_func
+from cnake_charmer.py.simulation.particle_bounce import particle_bounce as py_func
+
+
+@pytest.mark.parametrize("n", [10, 100, 500, 1000])
+def test_particle_bounce_equivalence(n):
+    py_result = py_func(n)
+    cy_result = cy_func(n)
+    assert abs(py_result - cy_result) < max(1e-3, abs(py_result) * 1e-9), (
+        f"Mismatch: py={py_result}, cy={cy_result}"
+    )

--- a/tests/sorting/test_heap_kth_smallest.py
+++ b/tests/sorting/test_heap_kth_smallest.py
@@ -1,0 +1,11 @@
+"""Test heap_kth_smallest equivalence."""
+
+import pytest
+
+from cnake_charmer.cy.sorting.heap_kth_smallest import heap_kth_smallest as cy_func
+from cnake_charmer.py.sorting.heap_kth_smallest import heap_kth_smallest as py_func
+
+
+@pytest.mark.parametrize("n", [200, 1000, 5000, 10000])
+def test_heap_kth_smallest_equivalence(n):
+    assert py_func(n) == cy_func(n)

--- a/tests/string_processing/test_classify_transitions.py
+++ b/tests/string_processing/test_classify_transitions.py
@@ -1,0 +1,15 @@
+"""Test classify_transitions equivalence."""
+
+import pytest
+
+from cnake_charmer.cy.string_processing.classify_transitions import (
+    classify_transitions as cy_func,
+)
+from cnake_charmer.py.string_processing.classify_transitions import (
+    classify_transitions as py_func,
+)
+
+
+@pytest.mark.parametrize("n", [10, 100, 1000, 10000])
+def test_classify_transitions_equivalence(n):
+    assert py_func(n) == cy_func(n)


### PR DESCRIPTION
…and memoryviews

Introduce py/cy/test triplets that exercise Cython features beyond plain functions: cdef class with __cinit__/__dealloc__ (ring_buffer_mean, deque_sliding_max, heap_kth_smallest, particle_bounce, polygon_area_centroid, rpn_eval), cdef enum (classify_transitions, rpn_eval), typed memoryviews via pointer cast (memview_weighted_sum, matrix_power_trace, image_flip_checksum), @property on extension types (particle_bounce), and cpdef methods (polygon_area_centroid). All 40 equivalence tests pass.