### PR TITLE
feat: wiki integration — read during traces, LLM reflection, flock sa…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,13 @@ unsloth_compiled_cache/
 .claude/worktrees/
 .codex/
 
+# Wiki raw sources (cloned locally, not committed)
+.sources/
+
+# Wiki merge artifacts
+wiki/pages/*.lock
+wiki/pages/*.tmp
+
 # mypy / pytype
 .mypy_cache/
 .pytype/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,15 +1,3 @@
 {
-  "mcpServers": {
-    "cnake-charmer": {
-      "type": "stdio",
-      "command": "uv",
-      "args": [
-        "run",
-        "python",
-        "-m",
-        "cnake_charmer.mcp_server"
-      ],
-      "env": {}
-    }
-  }
+  "mcpServers": {}
 }

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ traces:  ## Collect traces using a model profile
 	$(eval _MIT := $(shell $(call PROFILE_GET,collection.max_iters)))
 	$(eval _PAR := $(shell $(call PROFILE_GET,collection.parallel)))
 	$(eval _PRG := $(shell $(call PROFILE_GET,prompt.program)))
+	$(eval _WIK := $(shell $(call PROFILE_GET,wiki.enable)))
 	$(eval _EB := $(shell $(PROFILE_EB)))
 	$(UV_RUN) python scripts/collect_traces.py \
 		--model $$($(call PROFILE_GET,model.id)) \
@@ -31,6 +32,7 @@ traces:  ## Collect traces using a model profile
 		$(if $(filter-out None,$(_EB)),--extra-body '$(_EB)') \
 		$(if $(filter-out None,$(_PRG)),--program $(_PRG)) \
 		$(if $(filter True,$(_TR)),--thinking-react) \
+		$(if $(filter True,$(_WIK)),--enable-wiki) \
 		$(if $(filter-out None,$(_ATT)),--attempts $(_ATT)) \
 		$(if $(filter-out None,$(_MIT)),--max-iters $(_MIT)) \
 		$(if $(filter-out None,$(_PAR)),--parallel $(_PAR)) \
@@ -46,6 +48,7 @@ traces-best:  ## Collect best-of-N traces (5 attempts, keep best)
 	$(eval _MIT := $(shell $(call PROFILE_GET,collection.max_iters)))
 	$(eval _PAR := $(shell $(call PROFILE_GET,collection.parallel)))
 	$(eval _PRG := $(shell $(call PROFILE_GET,prompt.program)))
+	$(eval _WIK := $(shell $(call PROFILE_GET,wiki.enable)))
 	$(eval _EB := $(shell $(PROFILE_EB)))
 	$(UV_RUN) python scripts/collect_traces.py \
 		--model $$($(call PROFILE_GET,model.id)) \
@@ -54,6 +57,7 @@ traces-best:  ## Collect best-of-N traces (5 attempts, keep best)
 		$(if $(filter-out None,$(_EB)),--extra-body '$(_EB)') \
 		$(if $(filter-out None,$(_PRG)),--program $(_PRG)) \
 		$(if $(filter True,$(_TR)),--thinking-react) \
+		$(if $(filter True,$(_WIK)),--enable-wiki) \
 		$(if $(filter-out None,$(_MIT)),--max-iters $(_MIT)) \
 		$(if $(filter-out None,$(_PAR)),--parallel $(_PAR)) \
 		$(if $(filter-out None,$(_TMP)),--temperature $(_TMP)) \
@@ -90,6 +94,7 @@ sample:  ## Sample 3 random problems with a model
 	$(eval _TMP := $(shell $(call PROFILE_GET,model.temperature)))
 	$(eval _TOP := $(shell $(call PROFILE_GET,model.top_p)))
 	$(eval _PRG := $(shell $(call PROFILE_GET,prompt.program)))
+	$(eval _WIK := $(shell $(call PROFILE_GET,wiki.enable)))
 	$(eval _EB := $(shell $(PROFILE_EB)))
 	$(UV_RUN) python scripts/collect_traces.py \
 		--model $$($(call PROFILE_GET,model.id)) \
@@ -97,6 +102,7 @@ sample:  ## Sample 3 random problems with a model
 		$(if $(filter-out None,$(_EB)),--extra-body '$(_EB)') \
 		$(if $(filter-out None,$(_PRG)),--program $(_PRG)) \
 		$(if $(filter True,$(_TR)),--thinking-react) \
+		$(if $(filter True,$(_WIK)),--enable-wiki) \
 		$(if $(filter-out None,$(_TMP)),--temperature $(_TMP)) \
 		$(if $(filter-out None,$(_TOP)),--top-p $(_TOP)) \
 		--n-random 3 --attempts 1
@@ -146,6 +152,42 @@ optimize-prompt:  ## Optimize prompt for a model profile
 		$(if $(filter-out None,$(_TMP)),--temperature $(_TMP)) \
 		$(if $(filter-out None,$(_TOP)),--top-p $(_TOP)) \
 		$(if $(filter True,$(_TR)),--thinking-react)
+
+# --- Wiki ---
+.PHONY: wiki-setup wiki-reflect wiki-reflect-recent wiki-reflect-llm wiki-update-llm
+
+wiki-setup:  ## Clone Cython docs as wiki raw source
+	@mkdir -p .sources
+	@if [ ! -d .sources/cython-docs ]; then \
+		git clone --depth 1 --filter=blob:none --sparse \
+			https://github.com/cython/cython.git .sources/cython-docs && \
+		cd .sources/cython-docs && git sparse-checkout set docs; \
+	else echo "Cython docs already cloned"; fi
+
+wiki-reflect:  ## Extract patterns from traces into wiki findings
+	$(UV_RUN) python -m scripts.wiki_reflect \
+		--traces data/traces/master_traces.jsonl
+
+wiki-reflect-recent:  ## Reflect on traces from last 7 days
+	$(UV_RUN) python -m scripts.wiki_reflect \
+		--traces data/traces/master_traces.jsonl \
+		--since "$$(date -d '7 days ago' +%Y-%m-%d)"
+
+wiki-reflect-llm:  ## LLM reflection dry run (shows proposals)
+	$(eval _URL := $(shell $(call PROFILE_GET,model.base_url)))
+	$(UV_RUN) python -m scripts.wiki_reflect \
+		--traces data/traces/master_traces.jsonl \
+		--llm --dry-run \
+		--model $$($(call PROFILE_GET,model.id)) \
+		$(if $(filter-out None,$(_URL)),--base-url $(_URL))
+
+wiki-update-llm:  ## LLM reflection with apply (writes pages)
+	$(eval _URL := $(shell $(call PROFILE_GET,model.base_url)))
+	$(UV_RUN) python -m scripts.wiki_reflect \
+		--traces data/traces/master_traces.jsonl \
+		--llm --apply \
+		--model $$($(call PROFILE_GET,model.id)) \
+		$(if $(filter-out None,$(_URL)),--base-url $(_URL))
 
 # --- Utilities ---
 .PHONY: list-problems

--- a/cnake_charmer/mcp_server.py
+++ b/cnake_charmer/mcp_server.py
@@ -15,6 +15,8 @@ Usage:
 import ast
 import json
 import logging
+import os
+from datetime import datetime
 from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
@@ -23,6 +25,9 @@ from cnake_charmer.eval.annotations import parse_annotations
 from cnake_charmer.eval.compiler import cleanup_build, compile_cython
 from cnake_charmer.eval.memory_safety import check_memory_safety
 from cnake_charmer.eval.pipeline import composite_reward as _composite_reward
+from cnake_charmer.wiki.merge import atomic_wiki_write
+from cnake_charmer.wiki.search import wiki_read as _wiki_read
+from cnake_charmer.wiki.search import wiki_search as _wiki_search
 from cnake_data.loader import discover_pairs
 
 logger = logging.getLogger(__name__)
@@ -30,8 +35,12 @@ logger = logging.getLogger(__name__)
 mcp = FastMCP("cnake-charmer")
 
 CNAKE_DATA_ROOT = Path(__file__).resolve().parent.parent / "cnake_data"
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+WIKI_DIR = PROJECT_ROOT / "wiki"
+WIKI_PAGES = WIKI_DIR / "pages"
 PY_DIR = CNAKE_DATA_ROOT / "py"
 CY_DIR = CNAKE_DATA_ROOT / "cy"
+WIKI_READONLY = os.environ.get("WIKI_READONLY", "0") == "1"
 
 
 # ---------------------------------------------------------------------------
@@ -291,6 +300,143 @@ def check_memory(pyx_path: str, func_name: str, test_args: str = "(100,)") -> st
         },
         indent=2,
     )
+
+
+# ---------------------------------------------------------------------------
+# Wiki tools (read-only, always available)
+# ---------------------------------------------------------------------------
+
+
+def _wiki_page_path(page: str) -> Path:
+    """Resolve a page name to its file path."""
+    stem = page.removesuffix(".md")
+    return WIKI_PAGES / f"{stem}.md"
+
+
+@mcp.tool()
+def wiki_search(query: str, max_results: int = 5) -> str:
+    """Search wiki pages for relevant content.
+
+    Searches page titles and content for query terms. Returns matching
+    excerpts sorted by relevance.
+
+    Args:
+        query: Search terms (space-separated).
+        max_results: Maximum number of results to return.
+
+    Returns:
+        JSON array of {page, title, excerpt, score} sorted by relevance.
+    """
+    return _wiki_search(query, max_results=max_results, wiki_dir=WIKI_DIR)
+
+
+@mcp.tool()
+def wiki_read(page: str) -> str:
+    """Read a wiki page in full.
+
+    Args:
+        page: Page name (e.g. 'memoryviews' or 'memoryviews.md').
+
+    Returns:
+        Full markdown content of the page, or error with available pages.
+    """
+    return _wiki_read(page, wiki_dir=WIKI_DIR)
+
+
+# ---------------------------------------------------------------------------
+# Wiki tools (dev-only, gated by WIKI_READONLY)
+# ---------------------------------------------------------------------------
+
+if not WIKI_READONLY:
+
+    @mcp.tool()
+    def wiki_update(page: str, content: str) -> str:
+        """Create or update a wiki page.
+
+        Writes content to wiki/pages/{page}.md, appends to log.md,
+        and updates index.md if the page is new.
+
+        Args:
+            page: Page name (e.g. 'pitfalls' or 'new-topic').
+            content: Full markdown content for the page.
+
+        Returns:
+            Confirmation with page path.
+        """
+        path = _wiki_page_path(page)
+        stem = page.removesuffix(".md")
+        is_new = not path.exists()
+
+        WIKI_PAGES.mkdir(parents=True, exist_ok=True)
+        atomic_wiki_write(path, content)
+
+        # Append to log
+        log_path = WIKI_DIR / "log.md"
+        if log_path.exists():
+            ts = datetime.now().strftime("%Y-%m-%d")
+            op = "create" if is_new else "update"
+            entry = f"| {ts} | {op} | {stem} | mcp wiki_update |\n"
+            with open(log_path, "a") as f:
+                f.write(entry)
+
+        # Add to index if new
+        if is_new:
+            index_path = WIKI_DIR / "index.md"
+            if index_path.exists():
+                # Extract title from content
+                title = stem.replace("-", " ").title()
+                for line in content.splitlines():
+                    if line.startswith("# "):
+                        title = line[2:].strip()
+                        break
+                with open(index_path, "a") as f:
+                    f.write(f"\n- [{title}](pages/{stem}.md) — {stem}\n")
+
+        return json.dumps(
+            {
+                "success": True,
+                "page": stem,
+                "path": str(path),
+                "action": "created" if is_new else "updated",
+            },
+            indent=2,
+        )
+
+    @mcp.tool()
+    def wiki_reflect(
+        category: str | None = None,
+        problem_id: str | None = None,
+        min_reward: float = 0.0,
+        max_traces: int = 500,
+    ) -> str:
+        """Analyze traces and extract patterns for wiki improvement.
+
+        Loads traces matching the filter, extracts error types, fix patterns,
+        and optimization strategies, grouped by relevant wiki page.
+
+        Args:
+            category: Filter by problem category (e.g. 'numerical').
+            problem_id: Filter by specific problem (e.g. 'algorithms/a_star_grid').
+            min_reward: Minimum reward threshold (0.0-1.0).
+            max_traces: Maximum traces to analyze.
+
+        Returns:
+            JSON report of findings grouped by wiki page.
+        """
+        from cnake_charmer.wiki.reflect import reflect_on_traces
+
+        traces_path = PROJECT_ROOT / "data" / "traces" / "master_traces.jsonl"
+        if not traces_path.exists():
+            return json.dumps({"error": f"Traces not found at {traces_path}"})
+
+        findings = reflect_on_traces(
+            traces_path=traces_path,
+            category=category,
+            problem_id=problem_id,
+            min_reward=min_reward,
+            max_traces=max_traces,
+        )
+        return json.dumps(findings, indent=2)
 
 
 if __name__ == "__main__":

--- a/cnake_charmer/traces/lm.py
+++ b/cnake_charmer/traces/lm.py
@@ -130,10 +130,11 @@ class CythonReActAgent(dspy.Module):
             instead of dspy.ReAct (explicit next_thought field).
     """
 
-    def __init__(self, max_iters: int = 5, use_thinking: bool = False):
+    def __init__(self, max_iters: int = 5, use_thinking: bool = False, include_wiki: bool = False):
         super().__init__()
         self.max_iters = max_iters
         self.use_thinking = use_thinking
+        self.include_wiki = include_wiki
         self._init_react()
 
     @property
@@ -151,9 +152,23 @@ class CythonReActAgent(dspy.Module):
             """Compile, analyze, test, and benchmark Cython code in one step."""
             return "placeholder"
 
+        placeholder_tools = [evaluate_cython]
+
+        if self.include_wiki:
+
+            def wiki_read(page: str) -> str:
+                """Read a full Cython wiki page."""
+                return "placeholder"
+
+            def wiki_search(query: str) -> str:
+                """Search the Cython wiki."""
+                return "placeholder"
+
+            placeholder_tools.extend([wiki_read, wiki_search])
+
         self.react = self._react_cls(
             CythonOptimization,
-            tools=[evaluate_cython],
+            tools=placeholder_tools,
             max_iters=self.max_iters,
         )
 
@@ -176,7 +191,7 @@ class CythonReActAgent(dspy.Module):
         tc = json.loads(test_cases) if isinstance(test_cases, str) else test_cases
         ba = json.loads(benchmark_args) if isinstance(benchmark_args, str) else benchmark_args
 
-        tools, _env = make_tools(python_code, func_name, tc, ba)
+        tools, _env = make_tools(python_code, func_name, tc, ba, include_wiki=self.include_wiki)
         real_react = self._react_cls(CythonOptimization, tools=tools, max_iters=self.max_iters)
 
         for name, param in self.react.named_parameters():

--- a/cnake_charmer/training/dspy_agent.py
+++ b/cnake_charmer/training/dspy_agent.py
@@ -134,13 +134,16 @@ def _evaluate_worker(queue, env_args, code, annotate=True, test=True, benchmark=
 
 
 def make_tools(
-    python_code: str, func_name: str, test_cases: list, benchmark_args: tuple | None = None
+    python_code: str,
+    func_name: str,
+    test_cases: list,
+    benchmark_args: tuple | None = None,
+    include_wiki: bool = False,
 ):
-    """Create a single DSPy-compatible evaluation tool for a problem.
+    """Create DSPy-compatible tools for a problem.
 
-    One tool does everything: compile + annotate + test + benchmark.
-    Single compilation, single subprocess, all feedback at once.
-    The model calls evaluate_cython, reads the results, fixes issues, repeats.
+    Always includes evaluate_cython. Optionally adds wiki_read and wiki_search
+    (capped at 2 total wiki calls per episode) when include_wiki=True.
     """
     env_args = {
         "python_code": python_code,
@@ -199,7 +202,49 @@ def make_tools(
 
     env = CythonToolEnvironment()
     env.reset(**env_args)
-    return [evaluate_cython], env
+
+    tools = [evaluate_cython]
+
+    if include_wiki:
+        from cnake_charmer.wiki.search import wiki_read as _wiki_read_fn
+        from cnake_charmer.wiki.search import wiki_search as _wiki_search_fn
+
+        _wiki_calls = 0
+        _WIKI_LIMIT = 2
+
+        def wiki_read(page: str) -> str:
+            """Read a full Cython wiki page. Returns the complete page content with
+            patterns, code examples, gotchas, and trace statistics.
+
+            Available pages: typing, memoryviews, numpy-interop, parallelism,
+            optimization, compiler-directives, pitfalls, error-handling,
+            memory-management, c-interop, cpp-interop, extension-types, enums-tuples
+
+            Args:
+                page: Page name (e.g. 'memoryviews', 'pitfalls', 'parallelism').
+            """
+            nonlocal _wiki_calls
+            _wiki_calls += 1
+            if _wiki_calls > _WIKI_LIMIT:
+                return "Wiki read limit reached. Use evaluate_cython to iterate on your code."
+            return _wiki_read_fn(page)
+
+        def wiki_search(query: str) -> str:
+            """Search the Cython wiki to find which pages are relevant to your query.
+            Returns page names and short excerpts. Use wiki_read to get full content.
+
+            Args:
+                query: Search terms (e.g. 'memoryview contiguous', 'nogil prange').
+            """
+            nonlocal _wiki_calls
+            _wiki_calls += 1
+            if _wiki_calls > _WIKI_LIMIT:
+                return "Wiki search limit reached. Use evaluate_cython to iterate on your code."
+            return _wiki_search_fn(query, max_results=3)
+
+        tools.extend([wiki_read, wiki_search])
+
+    return tools, env
 
 
 # ---------------------------------------------------------------------------
@@ -441,13 +486,16 @@ def cython_metric(
 # Process reward: credit tool usage patterns (Context-1 insight)
 # ---------------------------------------------------------------------------
 
-ALL_TOOLS = {"evaluate_cython"}
+ALL_TOOLS = {"evaluate_cython", "wiki_read", "wiki_search"}
 
 # Required tools — trace must call evaluate_cython at least once or reward is zeroed
 REQUIRED_TOOLS = {"evaluate_cython"}
 
-# Per-tool bonus for using each distinct tool
-TOOL_DIVERSITY_BONUS = 0.025  # +0.025 per tool used, max +0.10 for all 4
+# Wiki tools don't count toward diversity/iteration bonuses
+_WIKI_TOOLS = {"wiki_read", "wiki_search"}
+
+# Per-tool bonus for using each distinct non-wiki tool
+TOOL_DIVERSITY_BONUS = 0.025
 
 # Bonus for iterative improvement (compile → fail → fix → compile again)
 ITERATION_BONUS = 0.02  # +0.02 per additional compile call beyond the first
@@ -491,13 +539,14 @@ def extract_tool_usage(entry: dict) -> dict:
                         tool_calls.append(tool_name)
                         tools_used.add(tool_name)
 
-    compile_count = sum(1 for t in tool_calls if t == "compile_cython")
+    compile_count = sum(1 for t in tool_calls if t == "evaluate_cython")
+    non_wiki_tools = tools_used - _WIKI_TOOLS
     return {
         "tool_calls": tool_calls,
         "tools_used": tools_used,
         "total_calls": len(tool_calls),
         "compile_count": compile_count,
-        "unique_tools": len(tools_used),
+        "unique_tools": len(non_wiki_tools),
     }
 
 
@@ -513,7 +562,7 @@ def process_reward(entry: dict, require_all_tools: bool = True) -> float:
     """
     usage = extract_tool_usage(entry)
 
-    # Gate: must use all 4 tools at least once
+    # Gate: must use evaluate_cython at least once
     if require_all_tools:
         missing = REQUIRED_TOOLS - usage["tools_used"]
         if missing:
@@ -521,7 +570,7 @@ def process_reward(entry: dict, require_all_tools: bool = True) -> float:
 
     bonus = 0.0
 
-    # Tool diversity: +0.025 per unique tool used (max +0.10 for all 4)
+    # Tool diversity: +0.025 per unique non-wiki tool used
     bonus += usage["unique_tools"] * TOOL_DIVERSITY_BONUS
 
     # Iterative improvement: bonus for re-compiling (implies fix-and-retry)

--- a/cnake_charmer/training/environment.py
+++ b/cnake_charmer/training/environment.py
@@ -207,6 +207,7 @@ class CythonToolEnvironment:
 
         self.step_scores = []
         self.num_tool_calls = 0
+        self._wiki_calls = 0
         self.last_code = None
         self._original_python = python_code
 
@@ -480,6 +481,28 @@ class CythonToolEnvironment:
             cleanup_build(comp)
 
         return "\n\n".join(sections)
+
+    # -- Wiki tools (read-only, do NOT affect step_scores or num_tool_calls) --
+
+    _WIKI_LIMIT = 2
+
+    def wiki_read(self, page: str) -> str:
+        """Read a full Cython wiki page with patterns, code examples, and gotchas."""
+        self._wiki_calls += 1
+        if self._wiki_calls > self._WIKI_LIMIT:
+            return "Wiki limit reached. Use evaluate_cython to iterate on your code."
+        from cnake_charmer.wiki.search import wiki_read as _read
+
+        return _read(page)
+
+    def wiki_search(self, query: str) -> str:
+        """Search the Cython wiki to find relevant pages."""
+        self._wiki_calls += 1
+        if self._wiki_calls > self._WIKI_LIMIT:
+            return "Wiki limit reached. Use evaluate_cython to iterate on your code."
+        from cnake_charmer.wiki.search import wiki_search as _search
+
+        return _search(query, max_results=3)
 
     def _weighted_score(self, scores: dict, weights: dict | None = None) -> float:
         """Compute weighted composite score from a step's scores dict."""

--- a/cnake_charmer/wiki/llm_reflect.py
+++ b/cnake_charmer/wiki/llm_reflect.py
@@ -1,0 +1,273 @@
+"""
+LLM-powered wiki reflection agent.
+
+Uses a DSPy ReAct agent to analyze traces, read docs and reference code,
+and update wiki pages with real findings (code diffs, patterns, fixes).
+
+This replaces the regex-only approach with an agent that can:
+- Read current wiki page content
+- Read reference Cython implementations from cy/
+- Read official Cython documentation
+- Verify code snippets compile via evaluate_cython
+- Write updated wiki pages with flock safety
+"""
+
+import json
+import logging
+from pathlib import Path
+
+import dspy
+
+from cnake_charmer.wiki.merge import atomic_wiki_write
+from cnake_charmer.wiki.reflect import reflect_on_traces
+from cnake_charmer.wiki.search import wiki_read as _wiki_read
+from cnake_charmer.wiki.trace_analysis import (
+    format_trace_for_llm,
+    load_cython_docs,
+    load_reference_code,
+    select_example_traces,
+)
+
+logger = logging.getLogger(__name__)
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+_WIKI_DIR = _PROJECT_ROOT / "wiki"
+_WIKI_PAGES = _WIKI_DIR / "pages"
+
+
+# ---------------------------------------------------------------------------
+# DSPy Signature
+# ---------------------------------------------------------------------------
+
+
+class WikiCurator(dspy.Signature):
+    """Analyze Cython optimization traces and update a wiki page with new patterns and fixes.
+
+    You have access to trace data showing how models attempted Cython optimizations,
+    including what errors they hit and how they fixed them. Your job is to improve
+    the wiki page with concrete, verified patterns from these traces.
+
+    Read the current page first, then decide what to add or update based on the
+    trace evidence. Verify any code examples compile before adding them.
+    """
+
+    page_name: str = dspy.InputField(desc="Wiki page to update (e.g. 'pitfalls', 'memoryviews')")
+    regex_findings: str = dspy.InputField(
+        desc="Statistical summary from regex analysis: error counts, fix rates, top errors"
+    )
+    example_traces: str = dspy.InputField(
+        desc="Selected traces with code diffs showing error->fix patterns"
+    )
+    updated: bool = dspy.OutputField(desc="Whether the page was updated with new content")
+
+
+# ---------------------------------------------------------------------------
+# Tool functions for the reflection agent
+# ---------------------------------------------------------------------------
+
+
+def _make_reflection_tools(dry_run: bool = False):
+    """Create tool functions for the wiki reflection agent."""
+
+    def wiki_read(page: str) -> str:
+        """Read a wiki page in full. Returns the complete markdown content.
+
+        Args:
+            page: Page name (e.g. 'memoryviews', 'pitfalls').
+        """
+        return _wiki_read(page)
+
+    def wiki_update(page: str, content: str) -> str:
+        """Write updated content to a wiki page. Uses atomic file locking.
+
+        Args:
+            page: Page name (e.g. 'pitfalls').
+            content: Full markdown content for the page.
+        """
+        path = _WIKI_PAGES / f"{page.removesuffix('.md')}.md"
+        if dry_run:
+            preview = content[:500] + "..." if len(content) > 500 else content
+            return json.dumps(
+                {
+                    "dry_run": True,
+                    "page": page,
+                    "content_length": len(content),
+                    "preview": preview,
+                }
+            )
+
+        atomic_wiki_write(path, content)
+
+        # Append to log
+        from datetime import datetime
+
+        log_path = _WIKI_DIR / "log.md"
+        if log_path.exists():
+            ts = datetime.now().strftime("%Y-%m-%d")
+            entry = f"| {ts} | update | {page} | llm_reflect |\n"
+            with open(log_path, "a") as f:
+                f.write(entry)
+
+        return json.dumps({"success": True, "page": page, "content_length": len(content)})
+
+    def read_reference(category: str) -> str:
+        """Load reference Cython implementations from cy/ for a category.
+
+        Args:
+            category: Problem category (e.g. 'numerical', 'algorithms', 'graph').
+                      Or a wiki page name — will auto-map to relevant categories.
+        """
+        return load_reference_code(category)
+
+    def read_cython_docs(topic: str) -> str:
+        """Search official Cython documentation for a topic.
+
+        Requires `make wiki-setup` to have been run to clone docs.
+
+        Args:
+            topic: Search terms (e.g. 'memoryview', 'nogil prange', 'cdef class').
+        """
+        return load_cython_docs(topic)
+
+    def evaluate_cython(code: str, python_code: str, test_code: str) -> str:
+        """Compile and test a Cython code snippet to verify it works.
+
+        Use this to verify code examples before adding them to wiki pages.
+
+        Args:
+            code: Complete .pyx Cython source code.
+            python_code: Original Python source code (reference).
+            test_code: Equivalence test assertions.
+        """
+        from cnake_charmer.training.environment import CythonToolEnvironment
+
+        env = CythonToolEnvironment()
+        env.reset()
+        return env.evaluate_cython(code=code, python_code=python_code, test_code=test_code)
+
+    return [wiki_read, wiki_update, read_reference, read_cython_docs, evaluate_cython]
+
+
+# ---------------------------------------------------------------------------
+# Reflection agent
+# ---------------------------------------------------------------------------
+
+
+class WikiReflectionAgent(dspy.Module):
+    """Agentic wiki curator that reads traces, docs, and reference code to improve wiki pages."""
+
+    def __init__(self, max_iters: int = 8, dry_run: bool = False):
+        super().__init__()
+        tools = _make_reflection_tools(dry_run=dry_run)
+        self.react = dspy.ReAct(WikiCurator, tools=tools, max_iters=max_iters)
+
+    def forward(self, page_name: str, regex_findings: str, example_traces: str):
+        return self.react(
+            page_name=page_name,
+            regex_findings=regex_findings,
+            example_traces=example_traces,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+def run_reflection(
+    traces_path: Path,
+    model: str | None = None,
+    category: str | None = None,
+    since: str | None = None,
+    max_traces: int = 2000,
+    pages: list[str] | None = None,
+    dry_run: bool = False,
+    max_iters: int = 8,
+) -> dict:
+    """Run LLM-powered reflection on traces to update wiki pages.
+
+    1. Load traces, run regex reflect_on_traces() for statistics
+    2. For each wiki page with findings (or specified pages):
+       a. Select example traces with code diffs
+       b. Format regex findings + trace examples
+       c. Run WikiReflectionAgent
+    3. Return {page: {updated, reasoning}}
+
+    Args:
+        traces_path: Path to master_traces.jsonl.
+        model: LM model ID (if None, uses current dspy.settings.lm).
+        category: Filter traces by category.
+        since: ISO date filter for traces.
+        max_traces: Max traces to analyze.
+        pages: Specific pages to update (default: all with findings).
+        dry_run: If True, show proposed changes without writing.
+        max_iters: Max ReAct iterations per page.
+
+    Returns:
+        Dict mapping page names to {updated, error} results.
+    """
+    from cnake_charmer.traces.io import load_traces
+
+    # Step 1: Run regex analysis for statistics
+    logger.info("Running regex analysis...")
+    regex_results = reflect_on_traces(
+        traces_path=traces_path,
+        category=category,
+        min_reward=0.0,
+        max_traces=max_traces,
+        since=since,
+    )
+
+    findings = regex_results.get("findings", {})
+    if not findings:
+        logger.info("No findings from regex analysis.")
+        return {}
+
+    # Determine which pages to process
+    target_pages = pages if pages else list(findings.keys())
+    logger.info(f"Processing {len(target_pages)} pages: {target_pages}")
+
+    # Step 2: Load traces for example selection
+    traces = load_traces([traces_path])
+    if since:
+        from datetime import datetime
+
+        since_dt = datetime.fromisoformat(since)
+        traces = [t for t in traces if t.timestamp and t.timestamp >= since_dt]
+    if category:
+        traces = [t for t in traces if t.category == category]
+    traces = traces[:max_traces]
+
+    # Step 3: Create agent
+    agent = WikiReflectionAgent(max_iters=max_iters, dry_run=dry_run)
+
+    results = {}
+    for page in target_pages:
+        logger.info(f"Reflecting on page: {page}")
+
+        # Select and format example traces
+        examples = select_example_traces(traces, page, max_examples=5)
+        if not examples:
+            logger.info(f"  No example traces for {page}, skipping")
+            results[page] = {"updated": False, "reason": "no_examples"}
+            continue
+
+        formatted_traces = "\n\n---\n\n".join(format_trace_for_llm(t) for t in examples)
+
+        # Format regex findings for this page
+        page_findings = findings.get(page, {})
+        regex_summary = json.dumps(page_findings, indent=2)
+
+        try:
+            result = agent(
+                page_name=page,
+                regex_findings=regex_summary,
+                example_traces=formatted_traces,
+            )
+            results[page] = {"updated": result.updated}
+            logger.info(f"  {page}: updated={result.updated}")
+        except Exception as e:
+            logger.error(f"  {page}: error - {e}")
+            results[page] = {"updated": False, "error": str(e)}
+
+    return results

--- a/cnake_charmer/wiki/merge.py
+++ b/cnake_charmer/wiki/merge.py
@@ -1,0 +1,31 @@
+"""
+Atomic wiki page writes with page-level file locking.
+
+Prevents data loss when multiple processes (e.g. parallel reflection agents)
+write to the same wiki page concurrently.
+"""
+
+import fcntl
+from pathlib import Path
+
+
+def atomic_wiki_write(page_path: Path, content: str) -> None:
+    """Write wiki page content with page-level file lock.
+
+    Uses fcntl.flock for advisory locking and atomic rename for crash safety.
+
+    Args:
+        page_path: Path to the .md wiki page file.
+        content: Full markdown content to write.
+    """
+    page_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = page_path.with_suffix(".md.lock")
+
+    with open(lock_path, "w") as lock_fd:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        try:
+            tmp = page_path.with_suffix(".md.tmp")
+            tmp.write_text(content)
+            tmp.rename(page_path)  # atomic on same filesystem
+        finally:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)

--- a/cnake_charmer/wiki/reflect.py
+++ b/cnake_charmer/wiki/reflect.py
@@ -1,0 +1,341 @@
+"""
+Trace reflection engine — extracts patterns from agent traces for wiki curation.
+
+Parses structured observation text from traces to identify:
+- Common compilation errors and their fixes
+- Test failure patterns (output mismatches, segfaults)
+- Optimization strategies (annotation improvements, speedup techniques)
+- Error→fix sequences across iteration steps
+
+Used by both the CLI script (scripts/wiki_reflect.py) and the MCP tool.
+"""
+
+import logging
+import re
+from collections import Counter, defaultdict
+from datetime import datetime
+from pathlib import Path
+
+from cnake_charmer.traces.io import load_traces
+from cnake_charmer.traces.models import Trace
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Observation parsers
+# ---------------------------------------------------------------------------
+
+# Patterns for structured observation sections
+_RE_SEGFAULT = re.compile(r"exit -11|segfault", re.IGNORECASE)
+_RE_TIMEOUT = re.compile(r"timed?\s*out|killed.*time", re.IGNORECASE)
+_RE_COMPILE_ERROR = re.compile(r"Compilation failed")
+_RE_COMPILE_OK = re.compile(r"Compilation successful")
+_RE_ANNOTATION = re.compile(
+    r"Annotation score:\s*([\d.]+)\s*\((\d+)\s*Python-fallback lines\s*/\s*(\d+)\s*total\)"
+)
+_RE_TESTS = re.compile(r"Tests:\s*(\d+)/(\d+)\s*passed")
+_RE_SPEEDUP = re.compile(r"Speedup:\s*([\d.]+)x")
+_RE_FAIL_MISMATCH = re.compile(r"FAIL:.*Output mismatch")
+_RE_FAIL_CASE = re.compile(r"FAIL:\s*Case\s*\d+:\s*(.*)")
+_RE_CYTHON_ERROR = re.compile(r"^(.*\.pyx:\d+:\d+:\s*.+)$", re.MULTILINE)
+_RE_GIL_ERROR = re.compile(r"not allowed without the GIL|Coercion from Python.*without.*GIL")
+_RE_CDEF_ERROR = re.compile(r"Cdef statement not allowed here|cdef.*not allowed")
+_RE_NOGIL_ERROR = re.compile(r"not allowed in nogil|Operation not allowed without gil")
+
+
+class StepAnalysis:
+    """Parsed analysis of a single trace step's observation."""
+
+    def __init__(self, observation: str):
+        self.raw = observation
+        self.compiled = bool(_RE_COMPILE_OK.search(observation))
+        self.compile_failed = bool(_RE_COMPILE_ERROR.search(observation))
+        self.segfault = bool(_RE_SEGFAULT.search(observation))
+        self.timeout = bool(_RE_TIMEOUT.search(observation))
+
+        # Compilation error details
+        self.compile_errors: list[str] = _RE_CYTHON_ERROR.findall(observation)
+        self.gil_error = bool(_RE_GIL_ERROR.search(observation))
+        self.cdef_error = bool(_RE_CDEF_ERROR.search(observation))
+        self.nogil_error = bool(_RE_NOGIL_ERROR.search(observation))
+
+        # Annotation
+        ann_match = _RE_ANNOTATION.search(observation)
+        self.annotation_score = float(ann_match.group(1)) if ann_match else None
+        self.yellow_lines = int(ann_match.group(2)) if ann_match else None
+        self.total_lines = int(ann_match.group(3)) if ann_match else None
+
+        # Tests
+        test_match = _RE_TESTS.search(observation)
+        self.tests_passed = int(test_match.group(1)) if test_match else None
+        self.tests_total = int(test_match.group(2)) if test_match else None
+        self.test_mismatches = len(_RE_FAIL_MISMATCH.findall(observation))
+        self.fail_reasons = _RE_FAIL_CASE.findall(observation)
+
+        # Speedup
+        sp_match = _RE_SPEEDUP.search(observation)
+        self.speedup = float(sp_match.group(1)) if sp_match else None
+
+    @property
+    def error_type(self) -> str | None:
+        """Classify the primary error type for this step."""
+        if self.segfault:
+            return "segfault"
+        if self.compile_failed:
+            if self.gil_error:
+                return "gil_violation"
+            if self.cdef_error:
+                return "cdef_placement"
+            if self.nogil_error:
+                return "nogil_violation"
+            return "compilation_error"
+        if self.timeout:
+            return "timeout"
+        if (
+            self.tests_passed is not None
+            and self.tests_total is not None
+            and self.tests_passed < self.tests_total
+        ):
+            return "test_failure"
+        return None
+
+
+def analyze_trace(trace: Trace) -> dict:
+    """Analyze a single trace for patterns."""
+    steps = [StepAnalysis(s.observation) for s in trace.steps if s.tool_name != "finish"]
+
+    # Track error→fix sequences
+    error_fix_pairs = []
+    for i in range(len(steps) - 1):
+        cur, nxt = steps[i], steps[i + 1]
+        err = cur.error_type
+        if err and nxt.error_type != err:
+            error_fix_pairs.append(
+                {
+                    "error_type": err,
+                    "fixed_in_next": nxt.error_type is None,
+                    "step": i,
+                }
+            )
+
+    # Annotation progression
+    annotations = [
+        {"step": i, "score": s.annotation_score}
+        for i, s in enumerate(steps)
+        if s.annotation_score is not None
+    ]
+
+    # Speedup progression
+    speedups = [
+        {"step": i, "speedup": s.speedup} for i, s in enumerate(steps) if s.speedup is not None
+    ]
+
+    # All error types encountered
+    errors = [s.error_type for s in steps if s.error_type]
+
+    # Compile error messages
+    compile_errors = []
+    for s in steps:
+        compile_errors.extend(s.compile_errors)
+
+    return {
+        "problem_id": trace.problem_id,
+        "category": trace.category,
+        "model": trace.model,
+        "reward": trace.reward,
+        "num_steps": len(steps),
+        "errors": errors,
+        "error_fix_pairs": error_fix_pairs,
+        "annotations": annotations,
+        "speedups": speedups,
+        "compile_errors": compile_errors,
+        "final_annotation": annotations[-1]["score"] if annotations else None,
+        "final_speedup": speedups[-1]["speedup"] if speedups else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Wiki page mapping — which patterns belong on which page
+# ---------------------------------------------------------------------------
+
+_ERROR_TO_PAGE = {
+    "segfault": "pitfalls",
+    "gil_violation": "parallelism",
+    "cdef_placement": "pitfalls",
+    "nogil_violation": "parallelism",
+    "compilation_error": "pitfalls",
+    "test_failure": "pitfalls",
+    "timeout": "optimization",
+}
+
+_COMPILE_ERROR_TO_PAGE = {
+    "GIL": "parallelism",
+    "nogil": "parallelism",
+    "cdef": "typing",
+    "memoryview": "memoryviews",
+    "cimport": "c-interop",
+    "cppclass": "cpp-interop",
+    "struct": "c-interop",
+    "malloc": "memory-management",
+    "free": "memory-management",
+    "enum": "enums-tuples",
+    "except": "error-handling",
+    "prange": "parallelism",
+}
+
+
+def _classify_compile_error(error_msg: str) -> str:
+    """Map a compilation error message to a wiki page."""
+    error_lower = error_msg.lower()
+    for keyword, page in _COMPILE_ERROR_TO_PAGE.items():
+        if keyword.lower() in error_lower:
+            return page
+    return "pitfalls"
+
+
+# ---------------------------------------------------------------------------
+# Aggregate reflection
+# ---------------------------------------------------------------------------
+
+
+def reflect_on_traces(
+    traces_path: str | Path,
+    category: str | None = None,
+    problem_id: str | None = None,
+    min_reward: float = 0.0,
+    max_traces: int = 500,
+    since: str | None = None,
+) -> dict:
+    """Analyze traces and produce findings grouped by wiki page.
+
+    Args:
+        traces_path: Path to master_traces.jsonl.
+        category: Filter by problem category.
+        problem_id: Filter by specific problem.
+        min_reward: Minimum reward threshold.
+        max_traces: Max traces to process.
+        since: ISO date string — only include traces after this date.
+
+    Returns:
+        Dict with summary stats and findings grouped by wiki page.
+    """
+    traces = load_traces([traces_path])
+    logger.info(f"Loaded {len(traces)} traces")
+
+    # Filter
+    since_dt = datetime.fromisoformat(since) if since else None
+    filtered = []
+    for t in traces:
+        if category and t.category != category:
+            continue
+        if problem_id and t.problem_id != problem_id:
+            continue
+        if t.reward < min_reward:
+            continue
+        if since_dt and t.timestamp and t.timestamp < since_dt:
+            continue
+        filtered.append(t)
+        if len(filtered) >= max_traces:
+            break
+
+    logger.info(f"Analyzing {len(filtered)} traces after filtering")
+
+    if not filtered:
+        return {"summary": {"total_traces": 0}, "findings": {}}
+
+    # Analyze all traces
+    analyses = [analyze_trace(t) for t in filtered]
+
+    # Aggregate stats
+    error_counts = Counter()
+    error_by_category = defaultdict(Counter)
+    compile_error_msgs = Counter()
+    page_findings = defaultdict(
+        lambda: {
+            "error_patterns": Counter(),
+            "compile_errors": Counter(),
+            "fix_success_rate": {"fixed": 0, "total": 0},
+            "example_traces": [],
+        }
+    )
+
+    speedups = []
+    annotations = []
+    steps_to_success = []
+
+    for a in analyses:
+        # Error counts
+        for err in a["errors"]:
+            error_counts[err] += 1
+            error_by_category[a["category"]][err] += 1
+
+            page = _ERROR_TO_PAGE.get(err, "pitfalls")
+            page_findings[page]["error_patterns"][err] += 1
+
+        # Compile error messages → pages
+        for msg in a["compile_errors"]:
+            compile_error_msgs[msg] += 1
+            page = _classify_compile_error(msg)
+            # Truncate long messages for readability
+            short_msg = msg[:120] if len(msg) > 120 else msg
+            page_findings[page]["compile_errors"][short_msg] += 1
+
+        # Error→fix tracking
+        for pair in a["error_fix_pairs"]:
+            page = _ERROR_TO_PAGE.get(pair["error_type"], "pitfalls")
+            page_findings[page]["fix_success_rate"]["total"] += 1
+            if pair["fixed_in_next"]:
+                page_findings[page]["fix_success_rate"]["fixed"] += 1
+
+        # Annotation/speedup stats
+        if a["final_annotation"] is not None:
+            annotations.append(a["final_annotation"])
+        if a["final_speedup"] is not None:
+            speedups.append(a["final_speedup"])
+        steps_to_success.append(a["num_steps"])
+
+        # Keep a few example traces for high-error pages
+        if a["errors"]:
+            page = _ERROR_TO_PAGE.get(a["errors"][0], "pitfalls")
+            examples = page_findings[page]["example_traces"]
+            if len(examples) < 3:
+                examples.append(
+                    {
+                        "problem_id": a["problem_id"],
+                        "errors": a["errors"],
+                        "reward": round(a["reward"], 3),
+                    }
+                )
+
+    # Build summary
+    summary = {
+        "total_traces": len(filtered),
+        "traces_with_errors": sum(1 for a in analyses if a["errors"]),
+        "error_counts": dict(error_counts.most_common(20)),
+        "avg_steps": round(sum(steps_to_success) / len(steps_to_success), 1),
+        "avg_speedup": round(sum(speedups) / len(speedups), 1) if speedups else None,
+        "avg_annotation": round(sum(annotations) / len(annotations), 3) if annotations else None,
+        "top_compile_errors": dict(compile_error_msgs.most_common(10)),
+    }
+
+    if error_by_category:
+        summary["errors_by_category"] = {
+            cat: dict(counts.most_common(5)) for cat, counts in sorted(error_by_category.items())
+        }
+
+    # Serialize page findings
+    findings = {}
+    for page, data in sorted(page_findings.items()):
+        fix = data["fix_success_rate"]
+        findings[page] = {
+            "error_patterns": dict(data["error_patterns"].most_common(10)),
+            "compile_errors": dict(data["compile_errors"].most_common(10)),
+            "fix_success_rate": (
+                round(fix["fixed"] / fix["total"], 2) if fix["total"] > 0 else None
+            ),
+            "fix_attempts": fix["total"],
+            "example_traces": data["example_traces"],
+        }
+
+    return {"summary": summary, "findings": findings}

--- a/cnake_charmer/wiki/search.py
+++ b/cnake_charmer/wiki/search.py
@@ -1,0 +1,108 @@
+"""
+Reusable wiki search and read functions.
+
+Extracted from mcp_server.py so training code can import them
+without depending on the MCP server.
+"""
+
+import json
+import re
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+_DEFAULT_WIKI_DIR = _PROJECT_ROOT / "wiki"
+
+
+def _wiki_pages_dir(wiki_dir: Path | None = None) -> Path:
+    return (wiki_dir or _DEFAULT_WIKI_DIR) / "pages"
+
+
+def _available_pages(wiki_dir: Path | None = None) -> list[str]:
+    pages_dir = _wiki_pages_dir(wiki_dir)
+    if not pages_dir.exists():
+        return []
+    return sorted(p.stem for p in pages_dir.glob("*.md"))
+
+
+def wiki_read(page: str, wiki_dir: Path | None = None) -> str:
+    """Read a full wiki page.
+
+    Args:
+        page: Page name (e.g. 'memoryviews' or 'memoryviews.md').
+        wiki_dir: Optional wiki root directory (default: auto-detect).
+
+    Returns:
+        Full markdown content of the page, or JSON error with available pages.
+    """
+    pages_dir = _wiki_pages_dir(wiki_dir)
+    stem = page.removesuffix(".md")
+    path = pages_dir / f"{stem}.md"
+
+    if not path.exists():
+        available = _available_pages(wiki_dir)
+        return json.dumps(
+            {"error": f"Page '{page}' not found", "available_pages": available},
+            indent=2,
+        )
+
+    return path.read_text()
+
+
+def wiki_search(query: str, max_results: int = 5, wiki_dir: Path | None = None) -> str:
+    """Search wiki pages for relevant content.
+
+    Searches page titles and content for query terms. Returns matching
+    excerpts sorted by relevance.
+
+    Args:
+        query: Search terms (space-separated).
+        max_results: Maximum number of results to return.
+        wiki_dir: Optional wiki root directory (default: auto-detect).
+
+    Returns:
+        JSON array of {page, title, excerpt, score} sorted by relevance.
+    """
+    pages_dir = _wiki_pages_dir(wiki_dir)
+    if not pages_dir.exists():
+        return json.dumps({"error": "Wiki not found. Run scaffold first."})
+
+    terms = [t.lower() for t in query.split() if t]
+    if not terms:
+        return json.dumps({"error": "Empty query"})
+
+    results = []
+    for md_path in pages_dir.glob("*.md"):
+        content = md_path.read_text()
+        content_lower = content.lower()
+        page_stem = md_path.stem
+
+        # Score: title match (3x weight) + content term frequency
+        score = 0
+        for term in terms:
+            if term in page_stem:
+                score += 3
+            score += content_lower.count(term)
+
+        if score == 0:
+            continue
+
+        # Extract title from first heading
+        title = page_stem.replace("-", " ").title()
+        for line in content.splitlines():
+            if line.startswith("# "):
+                title = line[2:].strip()
+                break
+
+        # Find best excerpt -- first paragraph containing a query term
+        excerpt = ""
+        for para in re.split(r"\n\n+", content):
+            para_lower = para.lower()
+            if any(t in para_lower for t in terms):
+                clean = re.sub(r"^#+\s*", "", para).strip()
+                excerpt = clean[:200]
+                break
+
+        results.append({"page": page_stem, "title": title, "excerpt": excerpt, "score": score})
+
+    results.sort(key=lambda r: r["score"], reverse=True)
+    return json.dumps(results[:max_results], indent=2)

--- a/cnake_charmer/wiki/trace_analysis.py
+++ b/cnake_charmer/wiki/trace_analysis.py
@@ -1,0 +1,255 @@
+"""
+Trace analysis utilities for LLM-powered wiki reflection.
+
+Bridges the gap between regex-only reflection (which only reads observation text)
+and actual code changes (which live in tool_args["code"]).
+"""
+
+import difflib
+from pathlib import Path
+
+from cnake_charmer.traces.models import Trace
+from cnake_charmer.wiki.reflect import _ERROR_TO_PAGE, StepAnalysis
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+_CY_DIR = _PROJECT_ROOT / "cnake_data" / "cy"
+_DOCS_DIR = _PROJECT_ROOT / ".sources" / "cython-docs" / "docs" / "src"
+
+# Map wiki pages to categories for loading reference implementations
+_PAGE_TO_CATEGORIES = {
+    "typing": ["numerical", "algorithms"],
+    "memoryviews": ["numerical", "dsp"],
+    "numpy-interop": ["numerical", "statistics"],
+    "parallelism": ["simulation", "numerical"],
+    "optimization": ["algorithms", "sorting"],
+    "compiler-directives": ["numerical", "algorithms"],
+    "pitfalls": ["algorithms", "numerical"],
+    "error-handling": ["algorithms", "graph"],
+    "memory-management": ["algorithms", "graph"],
+    "c-interop": ["algorithms", "cryptography"],
+    "cpp-interop": ["algorithms", "graph"],
+    "extension-types": ["graph", "geometry"],
+    "enums-tuples": ["algorithms", "geometry"],
+}
+
+
+def extract_code_diffs(trace: Trace) -> list[dict]:
+    """Extract code diffs between consecutive evaluate_cython steps.
+
+    Returns list of dicts with: step index, error before/after, code diff summary.
+    Only includes steps where `tool_name == "evaluate_cython"` and code changed.
+    """
+    eval_steps = []
+    for i, step in enumerate(trace.steps):
+        if step.tool_name == "evaluate_cython" and "code" in step.tool_args:
+            analysis = StepAnalysis(step.observation)
+            eval_steps.append((i, step.tool_args["code"], analysis))
+
+    diffs = []
+    for idx in range(len(eval_steps) - 1):
+        step_i, code_before, analysis_before = eval_steps[idx]
+        step_j, code_after, analysis_after = eval_steps[idx + 1]
+
+        diff_lines = list(
+            difflib.unified_diff(
+                code_before.splitlines(),
+                code_after.splitlines(),
+                lineterm="",
+                n=2,
+            )
+        )
+
+        if not diff_lines:
+            continue
+
+        diffs.append(
+            {
+                "step": step_i,
+                "error_before": analysis_before.error_type,
+                "error_after": analysis_after.error_type,
+                "fixed": analysis_before.error_type and not analysis_after.error_type,
+                "diff": "\n".join(diff_lines[:50]),  # cap for context
+            }
+        )
+
+    return diffs
+
+
+def select_example_traces(traces: list[Trace], page: str, max_examples: int = 5) -> list[Trace]:
+    """Select diverse, informative traces for a wiki page.
+
+    Prioritizes traces with:
+    - Errors mapped to this page
+    - Mix of successful fixes and failures
+    - Diverse error types
+    """
+    scored = []
+    for trace in traces:
+        score = 0
+        has_page_error = False
+
+        for step in trace.steps:
+            if step.tool_name != "evaluate_cython":
+                continue
+            analysis = StepAnalysis(step.observation)
+            err = analysis.error_type
+            if err and _ERROR_TO_PAGE.get(err, "pitfalls") == page:
+                has_page_error = True
+                score += 2
+
+        if not has_page_error:
+            continue
+
+        # Prefer traces with code diffs (shows actual fixes)
+        diffs = extract_code_diffs(trace)
+        if any(d["fixed"] for d in diffs):
+            score += 3  # successfully fixed
+        if diffs:
+            score += 1
+
+        # Prefer higher reward (more complete solutions)
+        score += trace.reward * 2
+
+        scored.append((score, trace))
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+
+    # Deduplicate by problem_id for diversity
+    seen_problems = set()
+    selected = []
+    for _, trace in scored:
+        if trace.problem_id in seen_problems:
+            continue
+        seen_problems.add(trace.problem_id)
+        selected.append(trace)
+        if len(selected) >= max_examples:
+            break
+
+    return selected
+
+
+def format_trace_for_llm(trace: Trace, max_code_lines: int = 40) -> str:
+    """Format a trace as concise text for LLM consumption.
+
+    Shows problem_id, reward, then per-step: thought + code diff + observation summary.
+    """
+    lines = [
+        f"## Trace: {trace.problem_id} (reward={trace.reward:.3f}, model={trace.model})",
+        "",
+    ]
+
+    diffs = extract_code_diffs(trace)
+    diff_by_step = {d["step"]: d for d in diffs}
+
+    for i, step in enumerate(trace.steps):
+        if step.tool_name != "evaluate_cython":
+            continue
+
+        analysis = StepAnalysis(step.observation)
+        lines.append(f"### Step {i}")
+
+        if step.thought:
+            lines.append(f"**Thought:** {step.thought[:200]}")
+
+        if i in diff_by_step:
+            d = diff_by_step[i]
+            diff_lines = d["diff"].splitlines()
+            if len(diff_lines) > max_code_lines:
+                diff_lines = diff_lines[:max_code_lines] + [
+                    f"... ({len(diff_lines) - max_code_lines} more lines)"
+                ]
+            lines.append("```diff")
+            lines.extend(diff_lines)
+            lines.append("```")
+
+        # Observation summary
+        obs_parts = []
+        if analysis.compile_failed:
+            obs_parts.append(f"compile_error: {analysis.error_type}")
+            if analysis.compile_errors:
+                obs_parts.append(f"  {analysis.compile_errors[0][:100]}")
+        elif analysis.compiled:
+            obs_parts.append("compiled: OK")
+        if analysis.tests_passed is not None:
+            obs_parts.append(f"tests: {analysis.tests_passed}/{analysis.tests_total}")
+        if analysis.speedup is not None:
+            obs_parts.append(f"speedup: {analysis.speedup:.1f}x")
+        if analysis.annotation_score is not None:
+            obs_parts.append(f"annotation: {analysis.annotation_score:.3f}")
+
+        if obs_parts:
+            lines.append("**Result:** " + " | ".join(obs_parts))
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def load_reference_code(page: str, max_files: int = 3) -> str:
+    """Load relevant cy/ implementations for a wiki page.
+
+    Returns concatenated source of up to max_files .pyx files from
+    categories mapped to this page.
+    """
+    categories = _PAGE_TO_CATEGORIES.get(page, ["numerical"])
+    files_found = []
+
+    for cat in categories:
+        cat_dir = _CY_DIR / cat
+        if not cat_dir.exists():
+            continue
+        for pyx in sorted(cat_dir.glob("*.pyx")):
+            files_found.append(pyx)
+            if len(files_found) >= max_files:
+                break
+        if len(files_found) >= max_files:
+            break
+
+    if not files_found:
+        return "No reference implementations found."
+
+    parts = []
+    for pyx in files_found:
+        content = pyx.read_text()
+        # Truncate very long files
+        lines = content.splitlines()
+        if len(lines) > 80:
+            lines = lines[:80] + [f"# ... ({len(lines) - 80} more lines)"]
+        parts.append(f"### {pyx.relative_to(_PROJECT_ROOT)}\n```cython\n{chr(10).join(lines)}\n```")
+
+    return "\n\n".join(parts)
+
+
+def load_cython_docs(topic: str, max_chars: int = 8000) -> str:
+    """Search .sources/cython-docs/docs/src/ for relevant official docs.
+
+    Simple keyword search over .rst files, returns best matching content.
+    """
+    if not _DOCS_DIR.exists():
+        return "Cython docs not available. Run `make wiki-setup` to clone them."
+
+    terms = [t.lower() for t in topic.split() if t]
+    if not terms:
+        return "Empty topic."
+
+    scored = []
+    for rst in _DOCS_DIR.rglob("*.rst"):
+        try:
+            content = rst.read_text()
+        except (OSError, UnicodeDecodeError):
+            continue
+        content_lower = content.lower()
+        score = sum(content_lower.count(t) for t in terms)
+        if score > 0:
+            scored.append((score, rst, content))
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+
+    if not scored:
+        return f"No docs found for '{topic}'."
+
+    # Return top result, truncated
+    _, path, content = scored[0]
+    if len(content) > max_chars:
+        content = content[:max_chars] + f"\n\n... (truncated, {len(content)} total chars)"
+
+    return f"## {path.relative_to(_DOCS_DIR)}\n\n{content}"

--- a/data/system_prompt.txt
+++ b/data/system_prompt.txt
@@ -54,12 +54,23 @@ free(arr)
 6. Sorting: use `qsort` from `libc.stdlib` with a `cdef int cmp(const void*, const void*) noexcept nogil` comparator.
 7. C math: `from libc.math cimport sin, cos, sqrt, log, exp, M_PI`.
 
+## Wiki Reference
+
+Available pages: typing, memoryviews, numpy-interop, parallelism, optimization,
+compiler-directives, pitfalls, error-handling, memory-management, c-interop,
+cpp-interop, extension-types, enums-tuples
+
+Call `wiki_read(page)` to read a full page of Cython patterns, code examples, and gotchas.
+Call `wiki_search(query)` to find which pages are relevant to a topic.
+Limited to 2 total wiki calls per problem — read early, then iterate with `evaluate_cython`.
+
 ## Process
 
-1. Write Cython with all variables typed (`cdef`)
-2. Call `evaluate_cython` with the code, python source, and equivalence tests
-3. Fix compilation errors first (move cdef to top, fix syntax)
-4. Fix correctness (check integer overflow, test failures)
-5. Improve annotation score toward >0.9 (add cdef, replace Python objects with C)
-6. Maximize speedup (malloc, nogil, precompute, avoid Python calls)
-7. Iterate until annotation >0.9 and tests pass
+1. Optionally read a relevant wiki page for patterns and gotchas
+2. Write Cython with all variables typed (`cdef`)
+3. Call `evaluate_cython` with the code, python source, and equivalence tests
+4. Fix compilation errors first (move cdef to top, fix syntax)
+5. Fix correctness (check integer overflow, test failures)
+6. Improve annotation score toward >0.9 (add cdef, replace Python objects with C)
+7. Maximize speedup (malloc, nogil, precompute, avoid Python calls)
+8. Iterate until annotation >0.9 and tests pass

--- a/data/tools.json
+++ b/data/tools.json
@@ -27,5 +27,43 @@
         ]
       }
     }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "wiki_read",
+      "description": "Read a full Cython wiki page with patterns, code examples, gotchas, and trace statistics. Available pages: typing, memoryviews, numpy-interop, parallelism, optimization, compiler-directives, pitfalls, error-handling, memory-management, c-interop, cpp-interop, extension-types, enums-tuples. Limited to 2 wiki calls total per problem.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "string",
+            "description": "Page name (e.g. 'memoryviews', 'pitfalls', 'parallelism')."
+          }
+        },
+        "required": [
+          "page"
+        ]
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "wiki_search",
+      "description": "Search the Cython wiki to find which pages cover a topic. Returns page names and excerpts. Use wiki_read to get full content. Limited to 2 wiki calls total per problem.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Search terms (e.g. 'memoryview contiguous', 'nogil prange')."
+          }
+        },
+        "required": [
+          "query"
+        ]
+      }
+    }
   }
 ]

--- a/scripts/collect_traces.py
+++ b/scripts/collect_traces.py
@@ -178,7 +178,15 @@ def score_trace(trace: Trace, problem) -> float:
     return scores["total"]
 
 
-def run_problem(problem, model_id, max_iters, optimized_program, seed_text, use_thinking=False):
+def run_problem(
+    problem,
+    model_id,
+    max_iters,
+    optimized_program,
+    seed_text,
+    use_thinking=False,
+    include_wiki=False,
+):
     """Run a single problem and return (result, lm_history)."""
     from copy import deepcopy
 
@@ -187,6 +195,7 @@ def run_problem(problem, model_id, max_iters, optimized_program, seed_text, use_
         problem.func_name,
         problem.test_cases,
         problem.benchmark_args,
+        include_wiki=include_wiki,
     )
     if use_thinking:
         from cnake_charmer.traces.thinking_react import ThinkingReAct
@@ -271,6 +280,12 @@ def main():
         action="store_true",
         default=False,
         help="Use ThinkingReAct (native LM thinking) instead of standard ReAct",
+    )
+    parser.add_argument(
+        "--enable-wiki",
+        action="store_true",
+        default=False,
+        help="Add wiki_read and wiki_search tools (capped at 2 calls per problem)",
     )
     parser.add_argument(
         "--extra-body",
@@ -416,6 +431,7 @@ def main():
                     optimized_program=optimized_program,
                     seed_text=seed_text,
                     use_thinking=args.thinking_react,
+                    include_wiki=args.enable_wiki,
                 ).with_inputs(
                     "problem",
                     "attempt",
@@ -424,6 +440,7 @@ def main():
                     "optimized_program",
                     "seed_text",
                     "use_thinking",
+                    "include_wiki",
                 )
                 exec_pairs.append((module, example))
 
@@ -438,6 +455,7 @@ def main():
                     optimized_program,
                     seed_text,
                     use_thinking=False,
+                    include_wiki=False,
                     **kwargs,
                 ):
                     result, lm_history = run_problem(
@@ -447,6 +465,7 @@ def main():
                         optimized_program,
                         seed_text,
                         use_thinking=use_thinking,
+                        include_wiki=include_wiki,
                     )
                     return dspy.Example(
                         result=result, lm_history=lm_history, problem=problem, attempt=attempt
@@ -498,6 +517,7 @@ def main():
                     optimized_program,
                     seed_text,
                     use_thinking=args.thinking_react,
+                    include_wiki=args.enable_wiki,
                 )
                 trace = make_trace(problem, result, args.model, prompt_id, attempt, lm_history)
                 trace.reward = score_trace(trace, problem)

--- a/scripts/train_grpo.py
+++ b/scripts/train_grpo.py
@@ -102,7 +102,7 @@ def _harmony_parse_tool_calls(text: str) -> dict:
         reasoning = m.group(1).strip()
 
     # Only recognize tools that the environment actually exposes
-    _KNOWN_TOOLS = {"evaluate_cython"}
+    _KNOWN_TOOLS = {"evaluate_cython", "wiki_read", "wiki_search"}
 
     tool_calls = []
     for m in _re.finditer(

--- a/scripts/wiki_reflect.py
+++ b/scripts/wiki_reflect.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+Reflect on agent traces and extract patterns for wiki curation.
+
+Usage:
+    # Regex-only: all traces (fast, no LLM)
+    python scripts/wiki_reflect.py --traces data/traces/master_traces.jsonl
+
+    # Filtered by category
+    python scripts/wiki_reflect.py --traces data/traces/master_traces.jsonl --category numerical
+
+    # Recent traces only
+    python scripts/wiki_reflect.py --traces data/traces/master_traces.jsonl --since 2026-03-01
+
+    # Output to file
+    python scripts/wiki_reflect.py --traces data/traces/master_traces.jsonl -o wiki/reflections.json
+
+    # LLM-powered reflection (dry run)
+    python scripts/wiki_reflect.py --traces data/traces/master_traces.jsonl --llm --dry-run
+
+    # LLM-powered reflection (apply changes)
+    python scripts/wiki_reflect.py --traces data/traces/master_traces.jsonl --llm --apply
+
+    # LLM reflection on specific pages
+    python scripts/wiki_reflect.py --traces data/traces/master_traces.jsonl --llm --apply --pages pitfalls,memoryviews
+"""
+
+import argparse
+import json
+import logging
+import sys
+
+from cnake_charmer.wiki.reflect import reflect_on_traces
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Reflect on traces for wiki curation")
+    parser.add_argument("--traces", required=True, help="Path to traces JSONL file")
+    parser.add_argument("--category", help="Filter by problem category")
+    parser.add_argument("--problem-id", help="Filter by specific problem ID")
+    parser.add_argument("--min-reward", type=float, default=0.0, help="Minimum reward threshold")
+    parser.add_argument("--max-traces", type=int, default=2000, help="Max traces to analyze")
+    parser.add_argument("--since", help="Only include traces after this date (YYYY-MM-DD)")
+    parser.add_argument("-o", "--output", help="Output file (default: stdout)")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Verbose logging")
+
+    # LLM reflection mode
+    parser.add_argument(
+        "--llm", action="store_true", help="Enable LLM-powered reflection (default: regex-only)"
+    )
+    parser.add_argument("--model", default=None, help="Model for LLM reflection")
+    parser.add_argument("--base-url", default=None, help="API base URL for LLM")
+    parser.add_argument(
+        "--pages", default=None, help="Comma-separated pages to update (default: all with findings)"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Show what would change without writing"
+    )
+    parser.add_argument("--apply", action="store_true", help="Actually write wiki updates")
+    parser.add_argument(
+        "--max-iters", type=int, default=8, help="Max ReAct iterations per page (LLM mode)"
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s: %(message)s",
+    )
+
+    if args.llm:
+        _run_llm_reflection(args)
+    else:
+        _run_regex_reflection(args)
+
+
+def _run_regex_reflection(args):
+    """Original regex-only reflection."""
+    findings = reflect_on_traces(
+        traces_path=args.traces,
+        category=args.category,
+        problem_id=args.problem_id,
+        min_reward=args.min_reward,
+        max_traces=args.max_traces,
+        since=args.since,
+    )
+
+    output = json.dumps(findings, indent=2)
+
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(output + "\n")
+        print(f"Wrote findings to {args.output}", file=sys.stderr)
+    else:
+        # Print summary to stderr, full JSON to stdout
+        summary = findings.get("summary", {})
+        print(f"Analyzed {summary.get('total_traces', 0)} traces", file=sys.stderr)
+        print(
+            f"  Traces with errors: {summary.get('traces_with_errors', 0)}",
+            file=sys.stderr,
+        )
+        print(f"  Avg steps: {summary.get('avg_steps')}", file=sys.stderr)
+        print(f"  Avg speedup: {summary.get('avg_speedup')}x", file=sys.stderr)
+        print(f"  Avg annotation: {summary.get('avg_annotation')}", file=sys.stderr)
+
+        n_pages = len(findings.get("findings", {}))
+        print(f"  Findings across {n_pages} wiki pages", file=sys.stderr)
+        print(file=sys.stderr)
+
+        print(output)
+
+
+def _run_llm_reflection(args):
+    """LLM-powered reflection using DSPy ReAct agent."""
+    if not args.apply and not args.dry_run:
+        print("LLM mode requires --apply or --dry-run", file=sys.stderr)
+        sys.exit(1)
+
+    import dspy
+
+    from cnake_charmer.wiki.llm_reflect import run_reflection
+
+    # Configure LM
+    if args.model:
+        lm_kwargs = {}
+        if args.base_url:
+            lm_kwargs["api_base"] = args.base_url
+        lm = dspy.LM(args.model, **lm_kwargs)
+        dspy.configure(lm=lm)
+
+    pages = args.pages.split(",") if args.pages else None
+
+    results = run_reflection(
+        traces_path=args.traces,
+        model=args.model,
+        category=args.category,
+        since=args.since,
+        max_traces=args.max_traces,
+        pages=pages,
+        dry_run=args.dry_run,
+        max_iters=args.max_iters,
+    )
+
+    print(json.dumps(results, indent=2))
+
+    updated = sum(1 for r in results.values() if r.get("updated"))
+    print(f"\nUpdated {updated}/{len(results)} pages", file=sys.stderr)
+    if args.dry_run:
+        print("(dry run — no files were written)", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,0 +1,24 @@
+# Wiki Index
+
+## Language Features
+- [Typing](pages/typing.md) — cdef, cpdef, fused types, ctypedef
+- [Extension Types](pages/extension-types.md) — cdef class, cinit/dealloc, special methods
+- [Enums and C-Tuples](pages/enums-tuples.md) — cdef enum, cpdef enum, C-tuples
+- [Error Handling](pages/error-handling.md) — except values, except *, exception translation
+
+## Data Access
+- [Typed Memoryviews](pages/memoryviews.md) — contiguous views, slicing, buffer protocol
+- [NumPy Interop](pages/numpy-interop.md) — typed arrays, ufuncs, pythran
+- [Memory Management](pages/memory-management.md) — malloc/free, calloc, realloc, buffer protocol
+
+## Interop
+- [C Interop](pages/c-interop.md) — cimport, extern, structs, unions, function pointers
+- [C++ Interop](pages/cpp-interop.md) — libcpp, cppclass, except+, templates
+
+## Performance
+- [Parallelism](pages/parallelism.md) — prange, nogil, schedule, reductions
+- [Compiler Directives](pages/compiler-directives.md) — boundscheck, wraparound, cdivision
+- [Optimization](pages/optimization.md) — annotation scores, reducing yellow lines, hot loops
+
+## Reference
+- [Common Pitfalls](pages/pitfalls.md) — integer overflow, object interaction, common mistakes

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,0 +1,26 @@
+# Wiki Log
+
+Append-only record of wiki operations.
+
+| Date | Operation | Pages | Source |
+|------|-----------|-------|--------|
+| 2026-04-07 | scaffold | all | initial creation |
+| 2026-04-07 | update | typing | mcp wiki_update |
+| 2026-04-07 | update | memory-management | mcp wiki_update |
+| 2026-04-07 | update | memoryviews | mcp wiki_update |
+| 2026-04-07 | update | error-handling | mcp wiki_update |
+| 2026-04-07 | update | compiler-directives | mcp wiki_update |
+| 2026-04-07 | update | numpy-interop | mcp wiki_update |
+| 2026-04-07 | update | pitfalls | mcp wiki_update |
+| 2026-04-07 | update | compiler-directives | mcp wiki_update |
+| 2026-04-07 | update | parallelism | mcp wiki_update |
+| 2026-04-07 | update | c-interop | mcp wiki_update |
+| 2026-04-07 | update | optimization | mcp wiki_update |
+| 2026-04-07 | update | parallelism | mcp wiki_update |
+| 2026-04-07 | update | optimization | mcp wiki_update |
+| 2026-04-07 | update | memoryviews | mcp wiki_update |
+| 2026-04-07 | update | numpy-interop | mcp wiki_update |
+| 2026-04-07 | update | pitfalls | mcp wiki_update |
+| 2026-04-07 | update | cpp-interop | mcp wiki_update |
+| 2026-04-07 | update | extension-types | mcp wiki_update |
+| 2026-04-07 | update | enums-tuples | mcp wiki_update |

--- a/wiki/pages/c-interop.md
+++ b/wiki/pages/c-interop.md
@@ -1,0 +1,314 @@
+# C Interop
+
+Calling C libraries, using structs, unions, and function pointers.
+
+## Overview
+
+Cython can directly call C functions with zero overhead. `cimport` pulls in C
+declarations, `cdef extern` wraps custom headers, and C structs/unions map to
+Cython types. This is how you access libc math, stdlib, and custom C code.
+
+## Trace Statistics
+
+| Source | Traces | Compile Errors | cimport Path Errors | `'X' is not a cimported module` |
+|--------|--------|---------------|--------------------|---------------------------------|
+| algorithms | 500 | 214 | 11 | 8 |
+| graph | 500 | 457 | 6 | 21 |
+| cryptography | 408 | 261 | -- | -- |
+| **Total** | **1408** | **932** | **~17** | **~29** |
+
+Top c-interop compile errors across 1408 traces:
+- `'np' is not a cimported module` -- 14+ instances (use `cimport numpy as np`)
+- `'libc/stdlib/memset.pxd' not found` -- 10 instances (memset is in `libc.string`)
+- `'array' is not a cimported module` -- 12+ instances
+- `'libc/stddef/NULL.pxd' not found` -- 4 instances (NULL needs no import)
+- `'cpython/object/PyLong_FromLong.pxd' not found` -- 3 instances (wrong granularity)
+- `'malloc' not a valid cython language construct` -- 1 instance (used without cimport)
+- Function pointer `except *` vs `noexcept` type mismatches -- 9 instances
+
+## Syntax
+
+```cython
+# libc imports -- the correct paths
+from libc.math cimport sin, cos, sqrt, log, exp, M_PI, INFINITY
+from libc.stdlib cimport malloc, free, calloc, realloc, qsort, abs as c_abs
+from libc.string cimport memcpy, memset, memcmp, strlen
+from libc.stdint cimport uint8_t, uint32_t, uint64_t, int32_t, int64_t
+from cpython.object cimport PyObject
+
+# Structs
+cdef struct Point:
+    double x
+    double y
+
+cdef struct Rect:
+    Point top_left
+    Point bottom_right    # nested struct
+
+# Struct -> dict conversion (automatic in Cython)
+def make_point(double x, double y) -> dict:
+    cdef Point p = Point(x=x, y=y)
+    return p  # auto-converts to dict
+
+# Unions
+cdef union IntFloat:
+    int as_int
+    float as_float
+
+# Function pointers
+ctypedef int (*comparator)(const void *, const void *) noexcept nogil
+
+cdef int cmp_double(const void *a, const void *b) noexcept nogil:
+    cdef double da = (<double *>a)[0]
+    cdef double db = (<double *>b)[0]
+    return (da > db) - (da < db)
+
+# Using qsort
+qsort(<void *>arr, n, sizeof(double), cmp_double)
+
+# Extern from header
+cdef extern from "mylib.h":
+    double my_function(double x)
+
+# Extern for inline C
+cdef extern from *:
+    """
+    static inline int fast_popcount(unsigned int x) {
+        return __builtin_popcount(x);
+    }
+    """
+    int fast_popcount(unsigned int x) noexcept nogil
+```
+
+## Patterns
+
+### cimport vs import: the critical distinction
+
+`cimport` brings in C-level declarations for use in `cdef` typed code.
+`import` brings in Python-level modules. Confusing them is a top error source.
+
+**BAD** -- using `import` where `cimport` is needed:
+```cython
+import numpy as np
+
+def typed_sum(double[:] arr):
+    cdef np.npy_intp i  # ERROR: 'np' is not a cimported module
+    cdef double total = 0.0
+    for i in range(arr.shape[0]):
+        total += arr[i]
+    return total
+```
+
+**GOOD** -- both import and cimport for NumPy:
+```cython
+import numpy as np
+cimport numpy as np
+
+def typed_sum(double[:] arr):
+    cdef np.npy_intp i
+    cdef double total = 0.0
+    for i in range(arr.shape[0]):
+        total += arr[i]
+    return total
+```
+
+### Correct cimport paths for libc
+
+Cython ships `.pxd` files organized by C header. The import path mirrors the
+header, NOT the function name.
+
+**BAD** -- wrong granularity, treating functions as submodules:
+```cython
+from libc.stdlib cimport memset      # ERROR: 'libc/stdlib/memset.pxd' not found
+from libc.stddef cimport NULL        # ERROR: 'libc/stddef/NULL.pxd' not found
+from cpython.object cimport PyLong_FromLong  # ERROR: wrong path
+```
+
+**GOOD** -- correct paths:
+```cython
+from libc.string cimport memset      # memset is in <string.h>, not <stdlib.h>
+from libc.stdlib cimport malloc, free # malloc/free are in <stdlib.h>
+from libc.math cimport sqrt, sin     # math functions in <math.h>
+
+# NULL is available automatically after any libc cimport, or:
+from libc.stdint cimport uint8_t     # stdint types
+```
+
+Reference table of common cimport paths:
+
+| Function/Type | Correct cimport | C Header |
+|---------------|----------------|----------|
+| `malloc`, `free`, `calloc`, `realloc` | `from libc.stdlib cimport ...` | `<stdlib.h>` |
+| `qsort`, `abs` | `from libc.stdlib cimport ...` | `<stdlib.h>` |
+| `memcpy`, `memset`, `memcmp`, `strlen` | `from libc.string cimport ...` | `<string.h>` |
+| `sin`, `cos`, `sqrt`, `log`, `exp` | `from libc.math cimport ...` | `<math.h>` |
+| `M_PI`, `INFINITY`, `NAN` | `from libc.math cimport ...` | `<math.h>` |
+| `uint8_t`, `uint32_t`, `int64_t` | `from libc.stdint cimport ...` | `<stdint.h>` |
+| `FILE`, `fopen`, `fclose` | `from libc.stdio cimport ...` | `<stdio.h>` |
+| `PyObject` | `from cpython.object cimport ...` | `<Python.h>` |
+| `Py_INCREF`, `Py_DECREF` | `from cpython.ref cimport ...` | `<Python.h>` |
+
+### NULL does not need its own cimport
+
+**BAD**:
+```cython
+from libc.stddef cimport NULL  # ERROR: 'libc/stddef/NULL.pxd' not found
+```
+
+**GOOD** -- NULL is a Cython builtin when you have any libc cimport:
+```cython
+from libc.stdlib cimport malloc, free
+
+cdef int *p = <int *>malloc(10 * sizeof(int))
+if p == NULL:
+    raise MemoryError()
+```
+
+Or just use the Pythonic `not` check:
+```cython
+if not p:
+    raise MemoryError()
+```
+
+### Struct definitions and usage
+
+Structs are declared with `cdef struct` at module level. They can be nested,
+passed by pointer, and automatically convert to/from Python dicts.
+
+```cython
+cdef struct Node:
+    int value
+    int left
+    int right
+
+cdef struct Edge:
+    int src
+    int dst
+    double weight
+
+# Initialize with keyword args
+cdef Node n = Node(value=10, left=-1, right=-1)
+
+# Or positional
+cdef Edge e = Edge(0, 1, 3.14)
+
+# Pass by pointer
+cdef void process_node(Node *n) noexcept nogil:
+    n.value += 1
+```
+
+### Wrapping C functions with extern
+
+Use `cdef extern from` to wrap functions from C headers or embed inline C.
+
+```cython
+# From a header file
+cdef extern from "fast_hash.h":
+    uint64_t hash64(const void *data, size_t len) noexcept nogil
+
+# Inline C (no header needed)
+cdef extern from *:
+    """
+    #include <immintrin.h>
+    static inline int popcount32(unsigned int x) {
+        return __builtin_popcount(x);
+    }
+    """
+    int popcount32(unsigned int x) noexcept nogil
+```
+
+### Function pointer signatures: noexcept matters
+
+When passing function pointers to C functions like `qsort`, the exception
+specification must match exactly. This caused 9+ compile errors in graph traces.
+
+**BAD** -- exception spec mismatch:
+```cython
+from libc.stdlib cimport qsort
+
+# Default Cython functions have "except *" -- incompatible with C callbacks
+cdef int my_cmp(const void *a, const void *b):  # implicit except *
+    return (<int *>a)[0] - (<int *>b)[0]
+
+qsort(arr, n, sizeof(int), my_cmp)  # ERROR: type mismatch
+```
+
+**GOOD** -- explicit noexcept nogil:
+```cython
+from libc.stdlib cimport qsort
+
+cdef int my_cmp(const void *a, const void *b) noexcept nogil:
+    return (<int *>a)[0] - (<int *>b)[0]
+
+qsort(arr, n, sizeof(int), my_cmp)  # OK
+```
+
+### The `'array' is not a cimported module` error
+
+This appears when trying to use `array` module typed access without proper
+cimport.
+
+**BAD**:
+```cython
+import array
+
+def sum_array(array.array a):  # ERROR: 'array' is not a cimported module
+    pass
+```
+
+**GOOD**:
+```cython
+from cpython cimport array
+import array
+
+def sum_array(array.array a):
+    cdef int[:] view = a
+    # work with the memoryview
+```
+
+## Gotchas
+
+1. **`'np' is not a cimported module`** is the most frequent c-interop error
+   (14+ instances). You must `cimport numpy as np` in addition to
+   `import numpy as np` to use `np.` in cdef type declarations. See
+   [[numpy-interop]].
+
+2. **`'libc/stdlib/memset.pxd' not found`** appears 10 times across traces.
+   `memset`, `memcpy`, and `memcmp` live in `libc.string`, not `libc.stdlib`.
+   This mirrors C where they are in `<string.h>`.
+
+3. **Function pointer `except *` vs `noexcept`** type mismatch. C callback
+   functions (for `qsort`, custom comparators) must be declared `noexcept
+   nogil`. The default Cython exception spec `except *` is incompatible with
+   C function pointer types.
+
+4. **`'libc/stddef/NULL.pxd' not found`**. Do not try to cimport NULL
+   directly. It is automatically available after any `libc` cimport, or you
+   can use the Pythonic `if not ptr:` check.
+
+5. **`'cpython/object/PyLong_FromLong.pxd' not found`**. Individual CPython
+   API functions cannot be cimported by name from sub-paths. Import from the
+   correct module: `from cpython.long cimport PyLong_FromLong`.
+
+6. **`'malloc' not a valid cython language construct`**. This occurs when
+   malloc is used in an expression without any cimport. Cython cannot parse it
+   as either a Python name or a C function. Fix: add
+   `from libc.stdlib cimport malloc`. See [[memory-management]].
+
+7. **Exception clause on Python-returning functions.** `cdef object func()
+   except *` is invalid -- functions returning Python objects always propagate
+   exceptions. Omit the except clause for such functions.
+
+8. **`Storing unsafe C derivative of temporary Python reference`**. Assigning
+   a C pointer from a temporary Python object (e.g., a bytes string) risks
+   dangling pointers. Store the Python object in a variable first.
+
+## See Also
+
+- [[memory-management]] -- malloc/free patterns, NULL checks, try/finally cleanup
+- [[cpp-interop]] -- C++ specific: STL containers, classes, templates
+- [[numpy-interop]] -- NumPy cimport, typed memoryviews with ndarray
+- [[typing]] -- cdef type declarations and placement rules
+- [[parallelism]] -- nogil requirements for C callbacks and prange
+- [[pitfalls]] -- general compilation error patterns
+- [[error-handling]] -- exception specs (noexcept, except *, except? -1)

--- a/wiki/pages/compiler-directives.md
+++ b/wiki/pages/compiler-directives.md
@@ -1,0 +1,185 @@
+# Compiler Directives
+
+Control Cython's code generation behavior.
+
+## Overview
+
+Directives disable safety checks for speed or enable special compilation modes.
+Set them file-wide via comments, per-function via decorators, or per-block
+via `with` statements.
+
+## Syntax
+
+```cython
+# File-wide (most common in our codebase)
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
+
+# Per-function
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def fast_sum(double[::1] arr):
+    ...
+
+# Per-block
+with cython.boundscheck(False):
+    result = arr[i]
+```
+
+## Key Directives
+
+| Directive | Default | Effect |
+|-----------|---------|--------|
+| `boundscheck` | True | Array bounds checking — disable in hot loops |
+| `wraparound` | True | Negative index support — disable when not needed |
+| `cdivision` | False | C-style division (no ZeroDivisionError, truncates toward zero) |
+| `language_level` | 2 | Always set to 3 for Python 3 semantics |
+| `initializedcheck` | True | Check memoryviews are initialized before access |
+| `nonecheck` | False | Check typed extension types for None before access |
+| `overflowcheck` | False | Check C integer arithmetic for overflow |
+| `binding` | True | Generate `__doc__`, `__module__` etc. for `def` functions |
+
+## Our Standard Header
+
+Every `.pyx` file in this project starts with:
+```cython
+# cython: boundscheck=False, wraparound=False, cdivision=True, language_level=3
+```
+
+## Patterns
+
+### File-Wide Header Format
+
+The header comment must be a single line with comma-separated `key=value` pairs. Newlines or extra content in the directive line cause parsing failures.
+
+```cython
+# BAD — directive line contains code after the value
+# cython: cdivision=True
+# ^^^ works, but this does NOT:
+# cython: cdivision=True\n\ndef my_func():  ...
+# ERROR: "cdivision directive must be set to True or False, got 'True\n\ndef...'"
+
+# BAD — directive value has trailing content
+# cython: wraparound=False\n\ncimport cython\n\ncpdef tuple lz77_...
+# ERROR: "wraparound directive must be set to True or False, got 'False\n\ncimport...'"
+
+# GOOD — clean single-line header
+# cython: boundscheck=False, wraparound=False, cdivision=True, language_level=3
+```
+
+This error appeared in traces across cryptography and compression categories when models embedded code in the directive line.
+
+### Per-Function Decorators vs File-Wide
+
+Use per-function decorators when only some functions need unsafe optimizations:
+
+```cython
+import cython
+
+# Safe default for the file
+def process_input(list data):
+    # boundscheck is ON here — good for user-facing code
+    ...
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def _hot_inner_loop(double[::1] arr):
+    # boundscheck OFF here — performance-critical
+    cdef int i
+    for i in range(arr.shape[0]):
+        arr[i] *= 2.0
+```
+
+### cdivision Safety
+
+`cdivision=True` gives C-style integer division (truncates toward zero, no ZeroDivisionError). This is faster but changes semantics:
+
+```cython
+# With cdivision=True:
+#   -7 // 2 == -3  (C truncation toward zero)
+#   7 // 0  → undefined behavior (no exception!)
+#
+# With cdivision=False (Python default):
+#   -7 // 2 == -4  (Python floor division)
+#   7 // 0  → ZeroDivisionError
+
+# Safe pattern: cdivision=True file-wide, but guard divisions
+# cython: cdivision=True
+cdef double safe_divide(double a, double b):
+    if b == 0.0:
+        return 0.0    # or raise, or return inf
+    return a / b
+```
+
+### initializedcheck and Memoryviews
+
+`initializedcheck=True` (default) checks that a memoryview is initialized before access. Disable for performance when you know the memoryview is always set:
+
+```cython
+@cython.initializedcheck(False)
+@cython.boundscheck(False)
+def fill_buffer(double[::1] buf, double value):
+    cdef int i
+    for i in range(buf.shape[0]):
+        buf[i] = value
+```
+
+### Non-Existent Directives
+
+Traces show models inventing directives that don't exist:
+
+```cython
+# BAD — these are NOT real Cython directives
+# cython: cython.parallel.atomic  → ERROR: "No such directive: cython.parallel.atomic"
+# cython: reduction               → not a directive
+# BAD — invalid prange keyword
+for i in prange(n, nogil=True, reduction='+'):  # ERROR: "Invalid keyword argument: reduction"
+    total += arr[i]
+
+# GOOD — prange auto-detects += as reduction
+for i in prange(n, nogil=True):
+    total += arr[i]    # += automatically treated as reduction
+```
+
+The `reduction` keyword appeared 22 times in numerical traces. Cython's prange handles reductions implicitly via `+=`, `-=`, `*=` operators.
+
+## Directive Combinations for Maximum Performance
+
+Typical high-performance combination used in traces achieving >1000x speedup:
+
+```cython
+# cython: boundscheck=False, wraparound=False, cdivision=True, language_level=3
+# cython: initializedcheck=False
+from cython.parallel cimport prange
+
+def fast_computation(double[::1] data):
+    cdef int i, n = data.shape[0]
+    cdef double total = 0.0
+    for i in range(n):          # or prange(n, nogil=True) if appropriate
+        total += data[i] * data[i]
+    return total
+```
+
+Average annotation scores across 2,795 traces: **0.846–0.898**, indicating most optimized code achieves >85% pure-C lines.
+
+## Trace Statistics
+
+Across ~2,800 traces from 6 categories:
+
+| Error Pattern | Count | Categories |
+|--------------|-------|------------|
+| cdivision/wraparound parse failure | 3+ | cryptography, compression, dynamic_programming |
+| "Invalid keyword argument: reduction" | 22+ | numerical |
+| "No such directive: cython.parallel.atomic" | 4 | numerical |
+| "'exceptval_check' not a valid cython attribute" | 2 | compression |
+
+## Gotchas
+
+1. **One-line header** — The `# cython:` directive must be self-contained on one line. No newlines in the value.
+2. **No `reduction` keyword** — prange auto-detects `+=`, `*=` etc. Don't pass `reduction=` argument.
+3. **cdivision + zero** — With `cdivision=True`, dividing by zero is undefined behavior, not an exception.
+4. **boundscheck scope** — File-wide `boundscheck=False` applies everywhere, including user-input-facing code. Prefer per-function decorators.
+5. **overflowcheck cost** — `overflowcheck=True` adds overhead to every integer operation. Use sparingly.
+
+## See Also
+
+[[optimization]], [[typing]], [[parallelism]], [[pitfalls]]

--- a/wiki/pages/cpp-interop.md
+++ b/wiki/pages/cpp-interop.md
@@ -1,0 +1,195 @@
+# C++ Interop
+
+Using C++ STL containers, classes, and templates from Cython.
+
+## Overview
+
+Cython can wrap C++ classes, use STL containers (vector, map, set), handle
+C++ exceptions, and instantiate templates. Requires `# distutils: language = c++`
+or auto-detection via `from libcpp` imports.
+
+## Syntax
+
+```cython
+# STL containers
+from libcpp.vector cimport vector
+from libcpp.map cimport map as cppmap
+from libcpp.set cimport set as cppset
+from libcpp.unordered_map cimport unordered_map
+from libcpp.pair cimport pair
+from libcpp.string cimport string
+from libcpp.queue cimport priority_queue
+
+cdef vector[int] v
+v.push_back(42)
+
+cdef cppmap[int, double] m
+m[1] = 3.14
+
+# Wrapping a C++ class
+cdef extern from "myclass.h":
+    cdef cppclass MinHeap:
+        MinHeap() except +
+        void push(int val) except +
+        int pop() except +
+        bint empty()
+
+# Inline C++ class
+cdef extern from *:
+    """
+    struct Vec2D {
+        double x, y;
+        Vec2D operator+(const Vec2D& o) const { return {x+o.x, y+o.y}; }
+    };
+    """
+    cdef cppclass Vec2D:
+        double x, y
+        Vec2D operator+(Vec2D)
+
+# Exception handling
+cdef extern from "lib.h":
+    double divide(double a, double b) except +              # translates any C++ exception
+    double safe_div(double a, double b) except +ValueError  # maps to specific Python exception
+```
+
+## Patterns
+
+### STL Containers as Fast Internal Data Structures
+
+STL containers can replace Python dicts/lists in hot code without GIL overhead:
+
+```cython
+from libcpp.vector cimport vector
+from libcpp.unordered_map cimport unordered_map
+
+def count_elements(int[::1] data):
+    cdef unordered_map[int, int] counts
+    cdef int i, n = data.shape[0]
+
+    for i in range(n):
+        counts[data[i]] += 1    # no Python dict overhead
+
+    # Convert back to Python only at the end
+    return dict(counts)
+```
+
+### priority_queue for Graph Algorithms
+
+Common in graph/algorithms traces for Dijkstra, A*, etc.:
+
+```cython
+from libcpp.queue cimport priority_queue
+from libcpp.pair cimport pair
+
+# BAD — using priority_queue without cimport
+cdef priority_queue[int] pq     # ERROR: 'priority_queue' is not a type identifier
+
+# GOOD — proper cimport
+from libcpp.queue cimport priority_queue
+
+# Min-heap pattern (negate values since STL priority_queue is max-heap)
+cdef priority_queue[pair[double, int]] pq
+pq.push(pair[double, int](-dist, node))
+
+while not pq.empty():
+    top = pq.top()
+    pq.pop()
+    cost = -top.first
+    node = top.second
+```
+
+### Nullary Constructor Requirement
+
+C++ classes must have a default (nullary) constructor to be stack-allocated in Cython:
+
+```cython
+# BAD — no default constructor
+cdef extern from *:
+    """
+    struct Foo {
+        Foo(int x) : val(x) {}  // no default constructor!
+        int val;
+    };
+    """
+    cdef cppclass Foo:
+        Foo(int x) except +
+
+cdef Foo f  # ERROR: C++ class must have a nullary constructor to be stack allocated
+
+# GOOD — add a default constructor
+cdef extern from *:
+    """
+    struct Foo {
+        Foo() : val(0) {}
+        Foo(int x) : val(x) {}
+        int val;
+    };
+    """
+    cdef cppclass Foo:
+        Foo() except +
+        Foo(int x) except +
+
+cdef Foo f       # stack allocated with default constructor
+cdef Foo f2 = Foo(42)  # or with argument
+```
+
+This error appeared in compression traces.
+
+### C++ Exception Translation
+
+The `except +` clause translates C++ exceptions to Python exceptions:
+
+```cython
+cdef extern from "lib.h":
+    double divide(double a, double b) except +              # any C++ exception → RuntimeError
+    int lookup(int key) except +IndexError                  # map to specific Python exception
+    void process() except +*                                # custom handler
+
+# If the C++ function throws std::bad_alloc → MemoryError
+# If it throws std::exception → RuntimeError with what() message
+# If it throws anything else → RuntimeError("Unknown exception")
+```
+
+### When C++ Interop Helps vs Pure C
+
+**Use C++** when:
+- You need hash maps, priority queues, or sorted containers (STL is well-optimized)
+- You're wrapping an existing C++ library
+- You need RAII-style resource management (destructors)
+- Graph algorithms that need dynamic data structures
+
+**Use pure C** when:
+- Maximum portability needed
+- Simple array-based algorithms
+- nogil blocks where you don't need containers
+- You want to avoid C++ compilation overhead
+
+### Converting STL Containers to Python
+
+```cython
+from libcpp.vector cimport vector
+from libcpp.map cimport map as cppmap
+
+# vector → Python list (automatic conversion)
+cdef vector[int] v
+v.push_back(1)
+v.push_back(2)
+py_list = list(v)    # [1, 2]
+
+# map → Python dict (automatic conversion)
+cdef cppmap[int, double] m
+m[1] = 3.14
+py_dict = dict(m)    # {1: 3.14}
+```
+
+## Gotchas
+
+1. **Type identifier not found** — `priority_queue`, `vector`, etc. need `from libcpp.X cimport X`. Without cimport, you get `'priority_queue' is not a type identifier`.
+2. **Nullary constructor** — Stack-allocated C++ objects need a default constructor. Use `new`/`del` for heap allocation if no default constructor exists.
+3. **except + required** — C++ constructors and methods that might throw need `except +` or exceptions are silently swallowed.
+4. **Language directive** — C++ features require `# distutils: language = c++` in the file or build configuration.
+5. **STL in nogil** — Most STL operations are C++ and work without GIL, but iterating with Python conversion requires GIL.
+
+## See Also
+
+[[c-interop]], [[typing]], [[memory-management]], [[error-handling]]

--- a/wiki/pages/enums-tuples.md
+++ b/wiki/pages/enums-tuples.md
@@ -1,0 +1,159 @@
+# Enums and C-Tuples
+
+Lightweight C-level enumerations and tuple return types.
+
+## Overview
+
+`cdef enum` creates C-level constants (compile-time, zero overhead).
+`cpdef enum` adds Python visibility. C-tuples return multiple values
+without Python tuple allocation overhead.
+
+## Syntax
+
+```cython
+# cdef enum — C-only constants
+cdef enum Direction:
+    NORTH = 0
+    EAST = 1
+    SOUTH = 2
+    WEST = 3
+
+# Anonymous enum — just constants
+cdef enum:
+    MAX_SIZE = 1024
+    HASH_MASK = 0xFF
+
+# cpdef enum — accessible from Python too
+cpdef enum TokenType:
+    INTEGER = 0
+    OPERATOR = 1
+    PAREN = 2
+
+# C-tuples — return multiple values without Python overhead
+cdef (double, double) minmax(double *arr, int n):
+    cdef double mn = arr[0], mx = arr[0]
+    for i in range(1, n):
+        if arr[i] < mn: mn = arr[i]
+        if arr[i] > mx: mx = arr[i]
+    return (mn, mx)
+
+cdef (long long, long long) divmod_c(long long a, long long b):
+    return (a // b, a % b)
+```
+
+## Patterns
+
+### Enum as Compile-Time Constants
+
+Enums replace magic numbers with named constants at zero cost:
+
+```cython
+cdef enum:
+    BUCKET_COUNT = 256
+    SEED = 0x9E3779B1
+
+def hash_histogram(unsigned char[::1] data):
+    cdef int counts[BUCKET_COUNT]    # uses enum constant
+    cdef int i, n = data.shape[0]
+    memset(counts, 0, BUCKET_COUNT * sizeof(int))
+    for i in range(n):
+        counts[data[i]] += 1
+    return [counts[i] for i in range(BUCKET_COUNT)]
+```
+
+### cpdef enum for Python-Visible Constants
+
+When Python code needs to reference the enum values:
+
+```cython
+cpdef enum Status:
+    OK = 0
+    ERROR = 1
+    TIMEOUT = 2
+
+def check_result(int code):
+    if code == Status.OK:       # works from both Cython and Python
+        return True
+    return False
+
+# From Python:
+# from module import Status
+# Status.OK  → 0
+```
+
+### C-Tuples for Multi-Return Without GIL
+
+Python tuples are Python objects and require the GIL. C-tuples are pure C:
+
+```cython
+# BAD — Python tuple in nogil block
+cdef object find_minmax(double *arr, int n) nogil:
+    # ERROR: cannot return Python object without GIL
+    return (arr[0], arr[1])
+
+# GOOD — C-tuple works in nogil
+cdef (double, double) find_minmax(double *arr, int n) noexcept nogil:
+    cdef double mn = arr[0], mx = arr[0]
+    cdef int i
+    for i in range(1, n):
+        if arr[i] < mn: mn = arr[i]
+        if arr[i] > mx: mx = arr[i]
+    return (mn, mx)
+
+# Usage from another nogil function:
+cdef void process(double *data, int n) noexcept nogil:
+    cdef (double, double) result = find_minmax(data, n)
+    cdef double lo = result[0]
+    cdef double hi = result[1]
+```
+
+This pattern avoids the "Constructing Python tuple not allowed without gil" error that appeared 20+ times in numerical traces. See [[parallelism]].
+
+### Enum Flags and Bit Manipulation
+
+```cython
+cdef enum Flags:
+    FLAG_READ = 1
+    FLAG_WRITE = 2
+    FLAG_EXEC = 4
+
+cdef bint has_flag(int flags, int flag) noexcept nogil:
+    return (flags & flag) != 0
+
+cdef int set_flag(int flags, int flag) noexcept nogil:
+    return flags | flag
+```
+
+### Struct vs C-Tuple for Multiple Values
+
+For more than 2-3 values, or when values have names, prefer a struct:
+
+```cython
+# C-tuple — fine for 2 values
+cdef (int, double) find_best(double *arr, int n) noexcept nogil:
+    ...
+
+# Struct — better for 3+ values or named fields
+cdef struct SearchResult:
+    int index
+    double value
+    bint found
+
+cdef SearchResult find_best(double *arr, int n, double target) noexcept nogil:
+    cdef SearchResult r
+    r.found = False
+    # ...
+    return r
+```
+
+## Gotchas
+
+1. **cdef enum is C-only** — `cdef enum` values are not accessible from Python. Use `cpdef enum` for Python visibility.
+2. **No string enums** — Cython enums are integer-only (like C enums). For string constants, use module-level `cdef` variables.
+3. **C-tuples need parentheses in type** — Declare as `cdef (int, int) result`, not `cdef int, int result`.
+4. **C-tuples are not Python tuples** — They can't be passed to Python functions or stored in Python containers without conversion.
+5. **Tuple construction in nogil** — Use C-tuples, not Python tuples, inside `nogil` or `prange` blocks.
+
+## See Also
+
+[[typing]], [[c-interop]], [[parallelism]]

--- a/wiki/pages/error-handling.md
+++ b/wiki/pages/error-handling.md
@@ -1,0 +1,377 @@
+# Error Handling
+
+Exception return values, propagation through nogil blocks, and C-level error handling.
+
+## Overview
+
+`cdef` functions need explicit error return specifications so Cython knows
+how to propagate exceptions across the C call boundary. Without them,
+exceptions inside `cdef` functions are **silently swallowed** -- one of the
+most dangerous Cython pitfalls. Choosing the right except clause also has
+direct performance implications: some forms require acquiring the GIL on
+every call, which defeats the purpose of nogil optimization.
+
+## Exception Clause Syntax
+
+### `except <value>` -- Sentinel Value
+
+The function returns a fixed sentinel on error. Cython checks the return
+value and only calls `PyErr_Occurred()` when it matches the sentinel.
+**Cheapest option** -- zero overhead when no exception occurs and the return
+value differs from the sentinel.
+
+```cython
+cdef int binary_search(int *arr, int n, int target) except -1:
+    if n <= 0:
+        raise ValueError("empty array")
+    # ... search logic ...
+    return index
+```
+
+Use this when you can guarantee a value the function never returns normally
+(e.g., `-1` for non-negative indices, `NAN` for doubles).
+
+### `except? <value>` -- Checked Sentinel
+
+Like `except <value>`, but Cython always calls `PyErr_Occurred()` when the
+return matches the sentinel, even if no exception was set. Small overhead
+from the extra check, but necessary when the sentinel is a valid return
+value.
+
+```cython
+from libc.math cimport sqrt, NAN
+
+cdef double safe_sqrt(double x) except? -1.0:
+    if x < 0:
+        raise ValueError("negative input")
+    return sqrt(x)
+```
+
+### `except *` -- Always Check
+
+Cython calls `PyErr_Occurred()` after **every** call. Safest but slowest
+option. Required when any return value is valid and no sentinel exists.
+
+```cython
+cdef bint contains(int *arr, int n, int val) except *:
+    cdef int i
+    for i in range(n):
+        if arr[i] == val:
+            return True
+    return False
+```
+
+**Performance note**: `except *` always requires the GIL to call
+`PyErr_Occurred()`. If used on a function called inside a `prange` or
+`nogil` block, Cython must re-acquire the GIL on every call. Traces show
+this as:
+
+> `performance hint: Exception check on 'compute_rhs' will always require the GIL to be acquired.`
+
+### `noexcept` -- No Exception Checking
+
+Tells Cython the function will never raise a Python exception. Zero
+overhead, fully compatible with `nogil`, but **any exception raised inside
+the function is silently lost**.
+
+```cython
+cdef inline double fast_dot(double *a, double *b, int n) noexcept nogil:
+    cdef double s = 0.0
+    cdef int i
+    for i in range(n):
+        s += a[i] * b[i]
+    return s
+```
+
+### C++ Exception Translation
+
+```cython
+cdef extern from "lib.h":
+    double divide(double a, double b) except +               # any C++ exception -> RuntimeError
+    int lookup(int key) except +IndexError                    # map to specific Python exception
+    void process() except +*                                  # custom handler
+```
+
+## Decision Tree: Which Except Form to Use
+
+```
+Is the function called from nogil / prange context?
+|
++-- YES --> Can the function actually raise Python exceptions?
+|           |
+|           +-- NO  --> Use `noexcept`
+|           +-- YES --> Can you acquire the GIL inside to handle it?
+|                       |
+|                       +-- YES --> Use `except <sentinel>` + `with gil:` for the raise
+|                       +-- NO  --> Use `noexcept`, handle errors via C return codes
+|
++-- NO --> Does the function return a C type?
+           |
+           +-- YES --> Is there a value the function never returns normally?
+           |           |
+           |           +-- YES --> Use `except <sentinel>` (fastest)
+           |           +-- NO  --> Is there a value that is *rarely* returned?
+           |                       |
+           |                       +-- YES --> Use `except? <value>`
+           |                       +-- NO  --> Use `except *` (accept GIL cost)
+           |
+           +-- NO (returns Python object) --> Do NOT add an except clause.
+                                              Python objects propagate exceptions
+                                              automatically via NULL return.
+```
+
+## Common Error: "Exception clause not allowed for function returning Python object"
+
+This is one of the most frequent error-handling compilation errors in the
+traces. It happens when you add an except clause to a function that returns
+a Python object (`list`, `dict`, `object`, `str`, etc.):
+
+```cython
+# BAD -- Python objects already use NULL as the error sentinel
+cdef list get_neighbors(int node) except *:
+    ...
+
+# BAD -- same problem with noexcept on Python-returning function
+cdef object parse_data(str text) noexcept:
+    ...
+```
+
+```cython
+# GOOD -- no except clause needed for Python object returns
+cdef list get_neighbors(int node):
+    ...
+
+cdef object parse_data(str text):
+    ...
+```
+
+Cython automatically returns `NULL` for Python objects on exception, and
+the caller checks for `NULL`. Adding any except clause (`except *`,
+`except -1`, or `noexcept`) is a compilation error.
+
+**Trace evidence**: This error appeared across diff_equations (5 instances),
+physics (3 instances), and algorithms categories.
+
+## Exception Propagation Through nogil Blocks
+
+When a `cdef noexcept nogil` function encounters a situation that should be
+an error, you cannot raise a Python exception directly. Use the
+`with gil:` pattern to temporarily re-acquire the GIL:
+
+```cython
+# BAD -- raises inside nogil without acquiring GIL
+cdef double compute_step(double *y, int n) noexcept nogil:
+    if n <= 0:
+        raise ValueError("bad size")  # Compile error: cannot raise without GIL
+    ...
+```
+
+```cython
+# GOOD -- acquire GIL to raise, use except clause to propagate
+cdef double compute_step(double *y, int n) except? -1.0 nogil:
+    if n <= 0:
+        with gil:
+            raise ValueError("bad size")
+    cdef double result = 0.0
+    cdef int i
+    for i in range(n):
+        result += y[i] * y[i]
+    return result
+```
+
+Note the function uses `except? -1.0` (not `noexcept`), because it *can*
+raise via the `with gil:` block. Using `noexcept` here would silently
+swallow the exception.
+
+**Pattern from traces**: The `with gil:` re-acquire pattern appears
+frequently in diff_equations (method_of_lines, midpoint_method) and physics
+(blackbody_radiation, capacitor_discharge) problems. Fix success rate for
+GIL violations was 67-86% across categories.
+
+## C Callback Functions Need `noexcept`
+
+When passing a Cython function as a C callback (e.g., to `qsort`, a
+numerical integrator, or any C library expecting a function pointer), the
+function **must** be declared `noexcept`. C function pointers have no
+concept of Python exceptions.
+
+```cython
+from libc.stdlib cimport qsort
+
+# BAD -- default except clause makes this incompatible with C function pointers
+cdef int compare(const void *a, const void *b):
+    return (<int*>a)[0] - (<int*>b)[0]
+
+# Compiler error:
+# Cannot assign type 'int (*)(const void *, const void *) except *' to
+# 'int (*)(const void *, const void *)'
+qsort(arr, n, sizeof(int), compare)
+```
+
+```cython
+# GOOD -- noexcept makes the signature match the C function pointer
+cdef int compare(const void *a, const void *b) noexcept:
+    return (<int*>a)[0] - (<int*>b)[0]
+
+qsort(arr, n, sizeof(int), compare)
+```
+
+**Trace evidence**: This exact error ("Cannot assign type 'int (...) except *'
+to 'int (...)'") appeared in the algorithms category (e.g., sorting
+problems using `qsort`). The fix is always to add `noexcept`.
+
+## C Library Error Handling: malloc NULL Checks and errno
+
+When calling C library functions, you must check for errors using C
+conventions -- return codes, NULL pointers, and `errno` -- rather than
+relying on Python exception mechanisms.
+
+### malloc NULL Checks
+
+```cython
+from libc.stdlib cimport malloc, free
+
+cdef double* allocate_buffer(int n) except NULL:
+    cdef double *buf = <double*>malloc(n * sizeof(double))
+    if buf == NULL:
+        raise MemoryError("Failed to allocate buffer")
+    return buf
+```
+
+Note: `except NULL` works for pointer-returning functions, using `NULL` as
+the sentinel value. See [[memory-management]] for full allocation patterns.
+
+### errno Checking
+
+```cython
+from libc.errno cimport errno
+from libc.string cimport strerror
+from libc.stdio cimport fopen, fclose, FILE
+
+cdef FILE* safe_open(const char *path) except NULL:
+    cdef FILE *f = fopen(path, "rb")
+    if f == NULL:
+        raise OSError(errno, strerror(errno).decode('utf-8'))
+    return f
+```
+
+## try/finally for Cleanup with C Allocations
+
+When mixing C allocations with code that might raise exceptions, use
+`try/finally` to guarantee cleanup. This is critical because Python's
+garbage collector does not manage C memory.
+
+```cython
+# BAD -- leak on exception
+cdef list process_data(double[:] input_view):
+    cdef int n = input_view.shape[0]
+    cdef double *temp = <double*>malloc(n * sizeof(double))
+    if temp == NULL:
+        raise MemoryError()
+
+    # If this raises, temp is leaked
+    result = do_computation(temp, n)
+    free(temp)
+    return result
+```
+
+```cython
+# GOOD -- try/finally guarantees cleanup
+cdef list process_data(double[:] input_view):
+    cdef int n = input_view.shape[0]
+    cdef double *temp = <double*>malloc(n * sizeof(double))
+    if temp == NULL:
+        raise MemoryError()
+
+    try:
+        result = do_computation(temp, n)
+        return result
+    finally:
+        free(temp)
+```
+
+For functions managing multiple allocations, nest the try/finally blocks or
+use a single cleanup block:
+
+```cython
+cdef object solve_system(int n):
+    cdef double *a = <double*>malloc(n * sizeof(double))
+    cdef double *b = NULL
+    if a == NULL:
+        raise MemoryError()
+    try:
+        b = <double*>malloc(n * sizeof(double))
+        if b == NULL:
+            raise MemoryError()
+        # ... computation ...
+        return build_result(a, b, n)
+    finally:
+        free(a)
+        if b != NULL:
+            free(b)
+```
+
+See [[memory-management]] for more allocation patterns including RAII-style
+wrappers.
+
+## noexcept vs except * Tradeoffs
+
+| Aspect | `noexcept` | `except *` |
+|---|---|---|
+| GIL required on call | No | Yes (calls `PyErr_Occurred()`) |
+| nogil compatible | Yes | No (forces GIL re-acquire) |
+| prange compatible | Yes | No |
+| C callback compatible | Yes | No |
+| Exception safety | Exceptions silently lost | All exceptions propagated |
+| Best for | Hot inner loops, callbacks | Functions that might raise |
+
+**When to prefer `noexcept`**:
+- Pure C arithmetic in tight loops (inner kernels)
+- Functions called from `prange` parallel loops
+- C callback functions passed to `qsort`, integrators, etc.
+- Functions where you have verified no Python exception can occur
+
+**When to prefer `except *` (or a sentinel form)**:
+- Functions that validate input and may raise
+- Functions that call Python/NumPy operations
+- Functions where silently lost exceptions would cause subtle bugs
+- Wrapper functions at the boundary between C and Python code
+
+**The middle ground**: Use `except <sentinel>` when possible. It gives you
+exception safety with minimal overhead (one comparison per call, no GIL
+acquire). Common sentinel choices:
+
+- `except -1` for int functions returning non-negative values
+- `except? -1.0` for double functions (any value could be valid)
+- `except NULL` for pointer-returning functions
+
+## Trace Statistics
+
+Analyzed **1,039 traces** across 3 categories (diff_equations, physics,
+algorithms):
+
+| Category | Traces | Error-Handling Errors | GIL Violations | Fix Rate |
+|---|---|---|---|---|
+| diff_equations | 314 | 6 (except clause on Python obj, noexcept syntax) | 6 | 67% |
+| physics | 225 | 4 (except clause on Python obj, noexcept syntax) | 8 | 86% |
+| algorithms | 500 | 2 (callback type mismatch) | 44 | 84% |
+| **Total** | **1,039** | **12** | **58** | **80% avg** |
+
+**Most common error-handling mistakes** (by frequency):
+1. **"Exception clause not allowed for function returning Python object"** -- 9 instances across diff_equations + physics. Models add `except *` or `except -1` to `cdef` functions returning `list`, `object`, etc.
+2. **"Exception check will always require the GIL"** -- 5 performance hints in diff_equations + physics. Models use `except *` on functions intended for nogil hot loops.
+3. **"Cannot assign type ... except * to ..."** -- 2 instances in algorithms. Models forget `noexcept` on C callback functions.
+4. **"Expected ':', found 'noexcept'"** -- 2 instances. Models place `noexcept` in wrong position (after return type instead of after parameters).
+
+**GIL violation resolution**: Across all categories, 58 traces hit GIL
+violations related to exception handling. The fix success rate averaged 80%,
+with the most common fix being addition of `noexcept` or switching from
+`except *` to a sentinel form.
+
+## See Also
+
+- [[parallelism]] -- GIL interaction with exception clauses in prange loops
+- [[memory-management]] -- malloc/free patterns and try/finally cleanup
+- [[pitfalls]] -- Common compilation errors including except clause mistakes
+- [[typing]] -- cdef function declarations and return types
+- [[cpp-interop]] -- C++ exception translation (`except +`)

--- a/wiki/pages/extension-types.md
+++ b/wiki/pages/extension-types.md
@@ -1,0 +1,224 @@
+# Extension Types
+
+`cdef class` — C-level classes with typed attributes and fast method dispatch.
+
+## Overview
+
+Extension types are Cython's equivalent of C structs with methods. Attributes
+are stored as C fields (no `__dict__`), giving direct memory access. Use them
+for data structures (trees, heaps, buffers) and stateful computation.
+
+## Syntax
+
+```cython
+cdef class Particle:
+    cdef double x, y, vx, vy
+    cdef readonly double mass        # readable from Python, not writable
+
+    def __cinit__(self, double x, double y, double mass):
+        self.x = x; self.y = y; self.mass = mass
+        self.vx = 0.0; self.vy = 0.0
+
+    def __dealloc__(self):
+        pass  # free any malloc'd memory here
+
+    cdef void step(self, double dt):  # C-only method (fast)
+        self.x += self.vx * dt
+        self.y += self.vy * dt
+
+    cpdef double energy(self):        # callable from both C and Python
+        return 0.5 * self.mass * (self.vx**2 + self.vy**2)
+
+    @property
+    def position(self):
+        return (self.x, self.y)
+
+# Inheritance
+cdef class ChargedParticle(Particle):
+    cdef double charge
+
+# Decorators
+@cython.final               # prevents subclassing, enables faster dispatch
+cdef class FastAccum:
+    cdef double total
+
+@cython.freelist(64)         # reuses deallocated objects (small, frequent allocs)
+cdef class Point:
+    cdef double x, y
+```
+
+## Patterns
+
+### __cinit__ vs __init__
+
+`__cinit__` is called before the object is fully constructed — use it for C-level initialization (malloc, field setup). `__init__` is the normal Python initializer.
+
+```cython
+cdef class Buffer:
+    cdef int *data
+    cdef int size
+
+    def __cinit__(self, int size):
+        # Called FIRST — guaranteed even if __init__ fails
+        # Use for C allocation
+        self.data = <int *>malloc(size * sizeof(int))
+        if not self.data:
+            raise MemoryError()
+        self.size = size
+        memset(self.data, 0, size * sizeof(int))
+
+    def __init__(self, int size):
+        # Called SECOND — for Python-level setup
+        pass
+
+    def __dealloc__(self):
+        # Always called — even if __init__ failed
+        if self.data:
+            free(self.data)
+```
+
+**Key rule**: `__cinit__` always runs, `__dealloc__` always runs. Pair malloc in `__cinit__` with free in `__dealloc__` for leak-free RAII.
+
+### Special Methods Must Use `def`
+
+This is a common trace error (16+ occurrences across numerical categories):
+
+```cython
+# BAD — cdef for special methods
+cdef class Node:
+    cdef int value
+
+    cdef int __len__(self):       # ERROR: Special methods must be declared with 'def', not 'cdef'
+        return 1
+
+    cdef str __repr__(self):      # ERROR: same issue
+        return f"Node({self.value})"
+
+# GOOD — special methods always use def
+cdef class Node:
+    cdef int value
+
+    def __len__(self):
+        return 1
+
+    def __repr__(self):
+        return f"Node({self.value})"
+```
+
+Special methods include: `__len__`, `__getitem__`, `__setitem__`, `__contains__`, `__iter__`, `__next__`, `__repr__`, `__str__`, `__hash__`, `__eq__`, `__lt__`, `__add__`, etc.
+
+### Attribute Access Control
+
+```cython
+cdef class Config:
+    cdef public int width, height     # read/write from Python
+    cdef readonly str name            # read-only from Python
+    cdef double _internal              # C-only (invisible from Python)
+
+    def __cinit__(self, str name, int w, int h):
+        self.name = name
+        self.width = w
+        self.height = h
+        self._internal = 0.0
+```
+
+### RAII Pattern for Manual Memory
+
+Pairing allocation with deallocation in cdef class:
+
+```cython
+from libc.stdlib cimport malloc, free
+
+cdef class SparseMatrix:
+    cdef double *values
+    cdef int *col_idx
+    cdef int *row_ptr
+    cdef int nnz, rows
+
+    def __cinit__(self, int rows, int nnz):
+        self.rows = rows
+        self.nnz = nnz
+        self.values = <double *>malloc(nnz * sizeof(double))
+        self.col_idx = <int *>malloc(nnz * sizeof(int))
+        self.row_ptr = <int *>malloc((rows + 1) * sizeof(int))
+        if not self.values or not self.col_idx or not self.row_ptr:
+            # __dealloc__ will clean up whatever was allocated
+            raise MemoryError()
+
+    def __dealloc__(self):
+        if self.values: free(self.values)
+        if self.col_idx: free(self.col_idx)
+        if self.row_ptr: free(self.row_ptr)
+```
+
+### @cython.final for Performance
+
+Final classes can't be subclassed, enabling direct method calls (no vtable lookup):
+
+```cython
+@cython.final
+cdef class IntStack:
+    cdef int *data
+    cdef int size, capacity
+
+    def __cinit__(self, int capacity=16):
+        self.data = <int *>malloc(capacity * sizeof(int))
+        if not self.data:
+            raise MemoryError()
+        self.size = 0
+        self.capacity = capacity
+
+    cdef void push(self, int val) noexcept:   # can be inlined due to @final
+        if self.size >= self.capacity:
+            self.capacity *= 2
+            self.data = <int *>realloc(self.data, self.capacity * sizeof(int))
+        self.data[self.size] = val
+        self.size += 1
+
+    cdef int pop(self) noexcept:
+        self.size -= 1
+        return self.data[self.size]
+
+    def __dealloc__(self):
+        if self.data: free(self.data)
+```
+
+### @cython.freelist for High-Throughput Allocation
+
+For small objects that are allocated and freed frequently:
+
+```cython
+@cython.freelist(256)
+cdef class TreeNode:
+    cdef int value
+    cdef TreeNode left, right
+
+    def __cinit__(self, int value):
+        self.value = value
+        self.left = None
+        self.right = None
+```
+
+The freelist caches 256 deallocated TreeNode objects and reuses them, avoiding malloc/free overhead.
+
+## Trace Statistics
+
+Across ~2,800 traces:
+
+| Error Pattern | Count | Categories |
+|--------------|-------|------------|
+| Special methods declared with cdef | 16+ | numerical, algorithms |
+| C struct/union/enum definition not allowed here | 1+ | compression |
+
+## Gotchas
+
+1. **`def` for special methods** — `__len__`, `__getitem__`, `__repr__`, etc. MUST use `def`, not `cdef` or `cpdef`.
+2. **__cinit__ vs __init__** — Use `__cinit__` for C-level init (malloc). It runs even if the subclass __init__ fails.
+3. **__dealloc__ runs always** — Even if __cinit__ partially fails (some allocs succeeded, some didn't). Check for NULL before free.
+4. **No __dict__ by default** — cdef class attributes must be declared. To allow arbitrary Python attrs, add `cdef dict __dict__`.
+5. **Inheritance constraints** — cdef classes can only inherit from other cdef classes (or object). Cannot inherit from regular Python classes.
+6. **cpdef methods incur overhead** — If a method is only called from Cython, use `cdef` for faster dispatch. Use `cpdef` only when Python needs to call it too.
+
+## See Also
+
+[[typing]], [[memory-management]], [[c-interop]], [[pitfalls]]

--- a/wiki/pages/memory-management.md
+++ b/wiki/pages/memory-management.md
@@ -1,0 +1,290 @@
+# Memory Management
+
+Manual memory allocation: malloc, free, calloc, realloc, buffer protocol.
+
+## Overview
+
+For hot loops that can't use Python objects, Cython provides direct access to
+C memory allocation. Always pair `malloc` with `free`, check for NULL returns,
+and use `__dealloc__` in `cdef class` for RAII-style cleanup.
+
+## Trace Statistics
+
+| Source | Traces | Segfaults | malloc/free Undeclared | libc Path Errors |
+|--------|--------|-----------|----------------------|-----------------|
+| algorithms | 500 | 53 | 10+ | 4 |
+| graph | 500 | 137 | 10+ | 6 |
+| cryptography | 408 | 3 | -- | -- |
+| **Total** | **1408** | **193** | **~20** | **~10** |
+
+Top memory-related compile errors across 1408 traces:
+- `undeclared name not builtin: malloc` -- ~10 instances
+- `undeclared name not builtin: free` -- ~10 instances
+- `'libc/stdlib/memset.pxd' not found` -- 10 instances (wrong cimport path; see [[c-interop]])
+- `Non-extern C function declared but not defined` -- 1 instance
+
+## Syntax
+
+```cython
+from libc.stdlib cimport malloc, free, calloc, realloc
+from libc.string cimport memcpy, memset, memcmp
+
+# Basic malloc pattern
+cdef int *arr = <int *>malloc(n * sizeof(int))
+if not arr:
+    raise MemoryError()
+try:
+    # ... use arr ...
+    pass
+finally:
+    free(arr)
+
+# calloc -- zero-initialized
+cdef int *counts = <int *>calloc(256, sizeof(int))
+
+# realloc -- resize
+cdef int *new_arr = <int *>realloc(arr, new_size * sizeof(int))
+if not new_arr:
+    free(arr)
+    raise MemoryError()
+arr = new_arr
+
+# memcpy, memset
+memcpy(dst, src, n * sizeof(double))
+memset(arr, 0, n * sizeof(int))
+
+# RAII via cdef class
+cdef class DynamicArray:
+    cdef int *data
+    cdef int size, capacity
+
+    def __cinit__(self, int capacity):
+        self.data = <int *>malloc(capacity * sizeof(int))
+        if not self.data:
+            raise MemoryError()
+        self.size = 0
+        self.capacity = capacity
+
+    def __dealloc__(self):
+        if self.data:
+            free(self.data)
+
+# Buffer protocol (expose C memory to Python/NumPy)
+cdef class DoubleBuffer:
+    cdef double *data
+    cdef Py_ssize_t n
+
+    def __getbuffer__(self, Py_buffer *buf, int flags):
+        buf.buf = <void *>self.data
+        buf.len = self.n * sizeof(double)
+        buf.itemsize = sizeof(double)
+        buf.ndim = 1
+        # ... set shape, strides, format ...
+
+    def __releasebuffer__(self, Py_buffer *buf):
+        pass
+```
+
+## Patterns
+
+### The cimport requirement
+
+The most common memory-management compile error is using `malloc` or `free`
+without the proper cimport. Cython does not provide these as builtins -- you
+must explicitly import them from `libc.stdlib`.
+
+**BAD** -- missing cimport causes `undeclared name not builtin: malloc`:
+```cython
+# No cimport!
+def allocate(int n):
+    cdef int *arr = <int *>malloc(n * sizeof(int))  # ERROR
+    free(arr)                                         # ERROR
+```
+
+**GOOD** -- proper cimport at module level:
+```cython
+from libc.stdlib cimport malloc, free
+
+def allocate(int n):
+    cdef int *arr = <int *>malloc(n * sizeof(int))
+    if not arr:
+        raise MemoryError()
+    try:
+        pass  # use arr
+    finally:
+        free(arr)
+```
+
+### NULL pointer checks after every allocation
+
+Every `malloc`, `calloc`, or `realloc` can return NULL. Skipping the check
+leads to segfaults -- the #1 runtime error in graph traces (137 segfaults out
+of 500 traces).
+
+**BAD** -- no NULL check:
+```cython
+from libc.stdlib cimport malloc, free
+
+cdef int *data = <int *>malloc(n * sizeof(int))
+data[0] = 42  # segfault if malloc returned NULL
+```
+
+**GOOD** -- always check:
+```cython
+from libc.stdlib cimport malloc, free
+
+cdef int *data = <int *>malloc(n * sizeof(int))
+if not data:
+    raise MemoryError()
+data[0] = 42
+```
+
+### try/finally for cleanup
+
+The biggest source of memory leaks is early returns or exceptions that skip
+the `free()` call. Always wrap manual memory in `try/finally`.
+
+**BAD** -- exception path leaks memory:
+```cython
+from libc.stdlib cimport malloc, free
+
+def process(int n):
+    cdef int *buf = <int *>malloc(n * sizeof(int))
+    if not buf:
+        raise MemoryError()
+    # If this raises, buf is never freed!
+    result = do_work(buf, n)
+    free(buf)
+    return result
+```
+
+**GOOD** -- try/finally guarantees cleanup:
+```cython
+from libc.stdlib cimport malloc, free
+
+def process(int n):
+    cdef int *buf = <int *>malloc(n * sizeof(int))
+    if not buf:
+        raise MemoryError()
+    try:
+        result = do_work(buf, n)
+        return result
+    finally:
+        free(buf)
+```
+
+### Multiple allocations with cascading cleanup
+
+When allocating multiple buffers, free everything on failure.
+
+**BAD** -- second malloc fails, first buffer leaks:
+```cython
+from libc.stdlib cimport malloc, free
+
+cdef int *a = <int *>malloc(n * sizeof(int))
+cdef int *b = <int *>malloc(n * sizeof(int))
+if not a or not b:
+    raise MemoryError()  # leaks a if b failed
+```
+
+**GOOD** -- cascading cleanup:
+```cython
+from libc.stdlib cimport malloc, free
+
+cdef int *a = NULL
+cdef int *b = NULL
+try:
+    a = <int *>malloc(n * sizeof(int))
+    if not a:
+        raise MemoryError()
+    b = <int *>malloc(n * sizeof(int))
+    if not b:
+        raise MemoryError()
+    # ... use a and b ...
+finally:
+    if b: free(b)
+    if a: free(a)
+```
+
+### Stack vs heap: when to use fixed-size C arrays
+
+For small, fixed-size buffers, use stack-allocated C arrays instead of malloc.
+No allocation overhead, no cleanup needed, and no risk of leaks.
+
+**GOOD** -- stack allocation for small known sizes:
+```cython
+# Stack-allocated: fast, no cleanup needed
+cdef int counts[256]   # fine for small arrays
+cdef double buf[64]
+
+# Use memset for initialization
+from libc.string cimport memset
+memset(counts, 0, 256 * sizeof(int))
+```
+
+**GOOD** -- heap allocation for large or dynamic sizes:
+```cython
+from libc.stdlib cimport malloc, free
+
+# Heap: required for runtime-sized or large allocations
+cdef int *data = <int *>malloc(n * sizeof(int))
+```
+
+Rule of thumb: stack for sizes known at compile time and under ~4KB; heap for
+everything else.
+
+### memset and memcpy usage
+
+Always import from `libc.string`, not `libc.stdlib` (see [[c-interop]] for
+the common `'libc/stdlib/memset.pxd' not found` error).
+
+```cython
+from libc.string cimport memset, memcpy
+
+# Zero-initialize an array
+cdef int arr[256]
+memset(arr, 0, 256 * sizeof(int))
+
+# Copy between buffers
+cdef int src[10]
+cdef int dst[10]
+memcpy(dst, src, 10 * sizeof(int))
+```
+
+## Gotchas
+
+1. **Missing cimport is the #1 error.** `malloc` and `free` are NOT builtins.
+   You must write `from libc.stdlib cimport malloc, free`. The error message
+   `undeclared name not builtin: malloc` appears across all problem categories.
+
+2. **Wrong import path for memset/memcpy.** `memset` lives in `libc.string`,
+   not `libc.stdlib`. Writing `from libc.stdlib cimport memset` gives
+   `'libc/stdlib/memset.pxd' not found`. See [[c-interop]].
+
+3. **No NULL check = segfault.** Graph problems had 137 segfaults in 500
+   traces. Many are caused by dereferencing a NULL pointer from a failed
+   malloc. Always check.
+
+4. **Early return without free.** If any code path between `malloc` and `free`
+   can raise an exception or return early, you have a memory leak. Use
+   `try/finally`.
+
+5. **realloc pitfall.** Never write `arr = realloc(arr, ...)`. If realloc
+   fails and returns NULL, you lose the original pointer. Always assign to a
+   temporary first.
+
+6. **Non-extern C function declared but not defined.** If you declare a `cdef`
+   function (e.g., `cdef void _free_tree(...)`) but forget to implement it,
+   you get a linker-style error. Every `cdef` function needs a body.
+
+7. **Recursive free in tree/graph structures.** In graph problems, manually
+   freeing tree nodes requires visiting every node. Prefer iterative free with
+   a stack to avoid C stack overflow on deep trees.
+
+## See Also
+
+- [[c-interop]] -- cimport paths, struct definitions, extern declarations
+- [[extension-types]] -- `__cinit__`/`__dealloc__` for RAII cleanup
+- [[memoryviews]] -- typed memoryviews as a safer alternative to raw pointers
+- [[pitfalls]] -- general compilation and runtime error patterns
+- [[error-handling]] -- exception safety with C memory

--- a/wiki/pages/memoryviews.md
+++ b/wiki/pages/memoryviews.md
@@ -1,0 +1,188 @@
+# Typed Memoryviews
+
+Fast, GIL-free access to contiguous memory buffers.
+
+## Overview
+
+Memoryviews provide C-pointer-speed access to NumPy arrays, C arrays, and any
+buffer-protocol object. They support slicing, transposition, and can be passed
+to C functions via `&view[0]`. The key to performance is specifying contiguity.
+
+## Syntax
+
+```cython
+# 1D, C-contiguous (fastest for row access)
+def process(double[::1] data):
+    cdef int i, n = data.shape[0]
+    for i in range(n):
+        data[i] *= 2.0
+
+# 2D, C-contiguous
+def matrix_op(double[:, ::1] mat):
+    cdef int rows = mat.shape[0], cols = mat.shape[1]
+
+# 2D, Fortran-contiguous (column-major)
+def col_sum(double[::1, :] mat):
+    ...
+
+# Const (read-only, allows compiler optimizations)
+def dot(const double[::1] a, const double[::1] b):
+    cdef double s = 0.0
+    for i in range(a.shape[0]):
+        s += a[i] * b[i]
+    return s
+
+# From malloc'd pointer
+cdef double *buf = <double *>malloc(n * sizeof(double))
+cdef double[:] view = <double[:n]>buf
+
+# Allocate via cython.view.array
+from cython.view cimport array
+cdef array tmp = array(shape=(rows, cols), itemsize=sizeof(double), format='d')
+cdef double[:, ::1] mat = tmp
+
+# Operations
+cdef double[:] copy = view.copy()   # deep copy
+cdef double[:, :] t = mat.T         # transpose (swaps strides)
+```
+
+## Patterns
+
+### Cannot Convert C Pointer to Memoryview
+
+You cannot directly assign a C pointer to a typed memoryview — you need the cast syntax:
+
+```cython
+from libc.stdlib cimport malloc, free
+
+# BAD — direct assignment fails
+cdef int* buf = <int*>malloc(n * sizeof(int))
+cdef int[::1] view = buf       # ERROR: Cannot convert 'int *' to memoryviewslice
+
+# GOOD — use cast syntax
+cdef int* buf = <int*>malloc(n * sizeof(int))
+cdef int[::1] view = <int[:n]>buf   # cast pointer to 1D memoryview
+
+# For 2D:
+cdef double* buf2d = <double*>malloc(rows * cols * sizeof(double))
+cdef double[:, ::1] mat = <double[:rows, :cols]>buf2d
+```
+
+This error appeared 8+ times in dynamic_programming and graph traces.
+
+### Cannot Convert void* to Memoryview
+
+malloc returns `void*` — you must cast to the typed pointer first:
+
+```cython
+# BAD — void* directly to memoryview
+cdef int[::1] view = <int[:n]>malloc(n * sizeof(int))
+# ERROR: Cannot convert 'void *' to memoryviewslice
+
+# GOOD — cast to typed pointer first
+cdef int* buf = <int*>malloc(n * sizeof(int))
+cdef int[::1] view = <int[:n]>buf
+```
+
+### Memoryview Shape Conformability
+
+Dimensions must match exactly:
+
+```cython
+# BAD — 1D memoryview assigned to 2D parameter
+cdef int[::1] flat = np.zeros(n, dtype=np.intc)
+cdef int[:, ::1] mat = flat    # ERROR: Memoryview 'int[::1]' not conformable to memoryview 'int[:, ::1]'
+
+# GOOD — reshape first
+import numpy as np
+cdef int[:, ::1] mat = np.zeros((rows, cols), dtype=np.intc)
+
+# Also BAD — wrong contiguity
+cdef int[:] generic = np.zeros(n, dtype=np.intc)
+cdef int[::1] contiguous = generic  # ERROR: 'int[:]' not conformable to 'int[::1]'
+
+# GOOD — ensure contiguity at creation
+cdef int[::1] contiguous = np.ascontiguousarray(data, dtype=np.intc)
+```
+
+### Cannot Take Address of Memoryview Slice
+
+```cython
+# BAD — slicing creates a temporary
+cdef int* ptr = &view[1:5]     # ERROR: Cannot take address of memoryview slice
+
+# GOOD — take address of first element of the slice
+cdef int* ptr = &view[1]       # pointer to element at index 1
+# Then use ptr[0], ptr[1], ..., ptr[3] for elements 1-4
+```
+
+### Python List to Memoryview
+
+Python lists cannot be directly assigned to memoryviews:
+
+```cython
+# BAD — Python list to typed memoryview
+cdef int[::1] arr = [0] * n    # ERROR: Cannot coerce multiplied list to 'int[:]'
+
+# GOOD — create numpy array first
+import numpy as np
+cdef int[::1] arr = np.zeros(n, dtype=np.intc)
+
+# GOOD — for small fixed arrays, use C array
+cdef int arr[256]    # stack-allocated, no Python overhead
+```
+
+This error appeared 14+ times in graph traces. It's one of the most common memoryview mistakes.
+
+### Memoryview Index Type Errors
+
+```cython
+# BAD — using wrong type to index
+cdef int[:] view = ...
+cdef long val = 5
+view[val] = 10    # may warn depending on context
+
+# GOOD — use Py_ssize_t or int for indices
+cdef Py_ssize_t idx = 5
+view[idx] = 10
+```
+
+## Returning Memoryviews
+
+Memoryviews cannot be directly returned to Python. Wrap in numpy:
+
+```cython
+import numpy as np
+
+def compute(int n):
+    cdef double[::1] result = np.empty(n)
+    cdef int i
+    for i in range(n):
+        result[i] = <double>i * <double>i
+    return np.asarray(result)    # convert back to numpy for Python
+```
+
+## Trace Statistics
+
+Across ~2,800 traces from 6 categories:
+
+| Error Pattern | Count | Categories |
+|--------------|-------|------------|
+| Cannot convert pointer to memoryviewslice | 8+ | dynamic_programming, graph |
+| Memoryview not conformable (shape mismatch) | 4+ | dynamic_programming, graph |
+| Cannot coerce multiplied list to memoryview | 14+ | graph |
+| Cannot convert void* to memoryviewslice | 3+ | dynamic_programming |
+| Cannot take address of memoryview slice | 1+ | dynamic_programming |
+| Invalid index for memoryview | 2+ | graph |
+
+## Gotchas
+
+1. **Lists aren't memoryviews** — `[0] * n` is a Python list. Use `np.zeros(n, dtype=...)`.
+2. **Cast pointers properly** — `malloc` → cast to typed pointer → cast to memoryview via `<type[:size]>ptr`.
+3. **Shape must match** — 1D can't go into 2D. Contiguous (`::1`) can't go into generic (`:`) slots easily.
+4. **Return as numpy** — Use `np.asarray(memoryview)` to return memoryviews to Python callers.
+5. **Contiguity matters** — `double[::1]` (C-contiguous) is faster than `double[:]` (strided). Always specify when possible.
+
+## See Also
+
+[[numpy-interop]], [[memory-management]], [[parallelism]], [[typing]]

--- a/wiki/pages/numpy-interop.md
+++ b/wiki/pages/numpy-interop.md
@@ -1,0 +1,183 @@
+# NumPy Interop
+
+Typed NumPy arrays, ufuncs, and Pythran integration.
+
+## Overview
+
+NumPy arrays accessed through typed memoryviews give C-speed element access.
+`@cython.ufunc` creates NumPy universal functions from scalar Cython code.
+Pythran can fuse NumPy expression trees for vectorized operations.
+
+## Syntax
+
+```cython
+# Typed memoryview from NumPy array
+import numpy as np
+cimport numpy as cnp
+
+def ewma(double[::1] data, double alpha):
+    cdef int i, n = data.shape[0]
+    cdef double[::1] out = np.empty(n)
+    out[0] = data[0]
+    for i in range(1, n):
+        out[i] = alpha * data[i] + (1.0 - alpha) * out[i-1]
+    return np.asarray(out)
+
+# Typed with cnp types
+def histogram(cnp.float64_t[::1] data, int n_bins):
+    ...
+
+# @cython.ufunc — auto-broadcasts, auto-parallelizes
+@cython.ufunc
+cdef double smoothstep(double x):
+    if x <= 0.0: return 0.0
+    if x >= 1.0: return 1.0
+    return x * x * (3.0 - 2.0 * x)
+
+# Fused type ufunc
+@cython.ufunc
+cdef cython.floating sigmoid(cython.floating x):
+    return 1.0 / (1.0 + exp(-x))
+```
+
+## The #1 Error: 'np' is not a cimported module
+
+This is the **most common NumPy-related compilation error** across all traces — 67+ occurrences in numerical alone. It happens when you use `import numpy as np` but try to use NumPy features that require `cimport`.
+
+```cython
+# BAD — only import, no cimport
+import numpy as np
+def func(np.float64_t[::1] data):    # ERROR: 'np' is not a cimported module
+    ...
+
+# GOOD — both import AND cimport
+import numpy as np
+cimport numpy as cnp
+
+def func(cnp.float64_t[::1] data):   # use cnp (cimported) for types
+    cdef cnp.ndarray[double, ndim=1] arr = np.empty(10)  # np for allocation
+    ...
+```
+
+**Rule**: Use `import numpy as np` for runtime operations (allocation, math). Use `cimport numpy as cnp` for compile-time type declarations. Many traces use `np` for both — that's the bug.
+
+Similarly for arrays:
+
+```cython
+# BAD
+from array import array
+cdef array.array a = array('i', [1,2,3])   # ERROR: 'array' is not a cimported module
+
+# GOOD
+from cpython cimport array
+import array
+cdef array.array a = array.array('i', [1,2,3])
+```
+
+## Don't Fight NumPy SIMD
+
+NumPy operations like `np.sum()`, `np.dot()`, `a + b` are already SIMD-optimized in C. Don't replace them with scalar Cython loops unless you have a specific reason.
+
+**When Cython beats NumPy**:
+- Fused operations (combine multiple passes into one loop)
+- Custom reductions not available in NumPy
+- Element-wise operations with branching/conditionals
+- Operations that need state between elements (running totals, EWMA)
+- Avoiding temporary array allocation
+
+**When NumPy beats Cython**:
+- Simple vectorized math (`a + b`, `np.sqrt(a)`)
+- Matrix multiplication (`np.dot`, `@` operator)
+- Operations on very large arrays (NumPy's BLAS/LAPACK)
+
+```cython
+# BAD — reimplementing what NumPy does better
+def slow_add(double[::1] a, double[::1] b):
+    cdef int i, n = a.shape[0]
+    cdef double[::1] out = np.empty(n)
+    for i in range(n):
+        out[i] = a[i] + b[i]    # NumPy's np.add is SIMD-optimized
+    return np.asarray(out)
+
+# GOOD — fuse operations NumPy can't
+def fused_normalize(double[::1] data):
+    """Compute mean, subtract it, and divide by std in ONE pass."""
+    cdef int i, n = data.shape[0]
+    cdef double total = 0.0, sq_total = 0.0, mean, std
+    cdef double[::1] out = np.empty(n)
+
+    for i in range(n):
+        total += data[i]
+    mean = total / n
+
+    for i in range(n):
+        out[i] = data[i] - mean
+        sq_total += out[i] * out[i]
+    std = (sq_total / n) ** 0.5
+
+    if std > 0:
+        for i in range(n):
+            out[i] /= std
+    return np.asarray(out)
+```
+
+## Creating Arrays Inside Loops
+
+A common performance trap: allocating NumPy arrays in a hot loop.
+
+```cython
+# BAD — allocation per iteration
+def bad_process(double[:, ::1] matrix):
+    cdef int i, rows = matrix.shape[0]
+    for i in range(rows):
+        row = np.array(matrix[i, :])   # allocation on every iteration!
+        ...
+
+# GOOD — allocate once, reuse
+def good_process(double[:, ::1] matrix):
+    cdef int i, rows = matrix.shape[0], cols = matrix.shape[1]
+    cdef double[::1] row_buf = np.empty(cols)
+    for i in range(rows):
+        row_buf[:] = matrix[i, :]      # copy into pre-allocated buffer
+        ...
+```
+
+## dtype Matching
+
+Ensure numpy dtype matches the Cython memoryview type:
+
+```cython
+# BAD — Python float (float64) to int memoryview
+cdef int[::1] arr = np.zeros(n)        # np.zeros defaults to float64!
+
+# GOOD — explicit dtype
+cdef int[::1] arr = np.zeros(n, dtype=np.intc)          # int
+cdef long long[::1] arr = np.zeros(n, dtype=np.int64)   # long long
+cdef double[::1] arr = np.zeros(n, dtype=np.float64)    # double (np.float64)
+cdef float[::1] arr = np.zeros(n, dtype=np.float32)     # float
+```
+
+## Trace Statistics
+
+Across ~2,800 traces:
+
+| Error Pattern | Count | Category |
+|--------------|-------|----------|
+| 'np' is not a cimported module | 67+ | numerical (dominant), graph, dp |
+| 'array' is not a cimported module | 11+ | dynamic_programming, graph |
+| dtype mismatch errors | scattered | all categories |
+
+The `cimport` error alone accounts for a significant fraction of all compilation errors in numerical problems.
+
+## Gotchas
+
+1. **cimport AND import** — You need both: `import numpy as np` (runtime) + `cimport numpy as cnp` (compile-time types).
+2. **Use cnp for types** — `cnp.float64_t`, `cnp.ndarray`, not `np.float64_t`.
+3. **Default dtype** — `np.zeros(n)` is float64, not int. Always specify `dtype=`.
+4. **Don't loop over numpy ops** — `np.sum()` is faster than a Cython loop over elements for simple reductions.
+5. **Fuse for wins** — Combine multiple numpy operations into one Cython loop to avoid temporary arrays.
+6. **Return as numpy** — Use `np.asarray(memoryview)` to return results to Python.
+
+## See Also
+
+[[memoryviews]], [[typing]], [[optimization]], [[c-interop]]

--- a/wiki/pages/optimization.md
+++ b/wiki/pages/optimization.md
@@ -1,0 +1,203 @@
+# Optimization
+
+Maximizing speedup and annotation quality.
+
+## Overview
+
+Cython generates HTML annotations showing which lines involve Python/C API calls
+(yellow) vs pure C (white). The annotation score (white/total ratio) is our
+primary optimization metric alongside wall-clock speedup.
+
+## Annotation Score
+
+```
+score = white_lines / total_lines
+```
+
+- **> 0.9**: Excellent — most code is pure C
+- **0.7–0.9**: Good — some Python interaction remains
+- **< 0.7**: Needs work — too many Python fallback lines
+
+Common causes of yellow lines:
+- Python object creation in loops
+- Untyped variables (falls back to `PyObject *`)
+- Python function calls (use `cdef` or `cpdef` instead)
+- String/dict/list operations
+
+### Annotation Scores from Traces
+
+Across ~2,800 traces:
+
+| Category | Avg Annotation | Avg Speedup | Notes |
+|----------|---------------|-------------|-------|
+| algorithms | 0.867 | 782x | Diverse patterns |
+| numerical | 0.858 | 1,427x | Heavy numpy interaction |
+| dynamic_programming | 0.898 | 6,464x | Clean loop structures |
+| graph | 0.846 | 4,750x | Pointer-heavy, more complex |
+| cryptography | 0.876 | 2,211x | Bit manipulation dominant |
+| compression | 0.891 | 5,450x | Byte-level processing |
+
+**Key insight**: Dynamic programming achieves the highest speedups (6,464x avg) and annotation scores (0.898) because DP problems have clean nested loops that map perfectly to typed C code.
+
+## Optimization Checklist
+
+1. **Type everything** — all loop variables, function params, local accumulators
+2. **C math** — `from libc.math cimport` instead of Python `math` module
+3. **C arrays** — `malloc`/`free` instead of Python lists in hot loops
+4. **Avoid Python objects** — no dicts, lists, sets inside inner loops
+5. **Use `cdef` functions** — for internal helper functions called in loops
+6. **Precompute** — move invariant calculations outside loops
+7. **Release the GIL** — `with nogil:` if no Python objects are needed
+8. **Directives** — `boundscheck=False, wraparound=False` for array-heavy code
+
+## Patterns
+
+### The Biggest Win: Typing Loop Variables
+
+The single most impactful optimization. An untyped loop variable forces Python integer objects on every iteration:
+
+```cython
+# BAD — i is a Python object, ~1x speedup
+def slow_sum(data):
+    total = 0.0
+    for i in range(len(data)):
+        total += data[i]
+    return total
+
+# GOOD — typed everything, annotation score jumps from ~0.3 to ~0.9
+def fast_sum(double[::1] data):
+    cdef int i, n = data.shape[0]
+    cdef double total = 0.0
+    for i in range(n):
+        total += data[i]
+    return total
+```
+
+### malloc vs Memoryview vs NumPy
+
+Choose based on context:
+
+```cython
+# malloc — best for: temporary scratch space, C-interop, nogil blocks
+# Pro: no Python overhead, works in nogil
+# Con: must manually free, no bounds checking
+from libc.stdlib cimport malloc, free
+
+cdef int* scratch = <int*>malloc(n * sizeof(int))
+if not scratch:
+    raise MemoryError()
+# ... use scratch ...
+free(scratch)
+
+# Memoryview — best for: function parameters, passing arrays between functions
+# Pro: typed, bounds-checked (optional), slice-friendly
+# Con: slight overhead vs raw pointer
+def process(double[::1] data):
+    cdef int i
+    for i in range(data.shape[0]):
+        data[i] *= 2.0
+
+# NumPy — best for: return values, allocation, vectorized operations
+# Pro: Python-visible, garbage collected, SIMD-optimized operations
+# Con: overhead for element-wise access in loops
+import numpy as np
+cdef double[::1] result = np.empty(n)
+```
+
+### Timeout Prevention
+
+12 timeouts observed across traces (60% fix rate). Common causes:
+
+```cython
+# BAD — infinite loop from integer overflow
+cdef int i = 0
+while i < n:
+    # if n > INT_MAX, i wraps around and never reaches n
+    i += 1
+
+# GOOD — use appropriate integer size
+cdef long long i = 0
+while i < n:
+    i += 1
+
+# BAD — O(n^3) algorithm with no early exit
+for i in range(n):
+    for j in range(n):
+        for k in range(n):
+            ...
+
+# GOOD — algorithmic optimization first, then Cython
+# Consider: can you reduce complexity before micro-optimizing?
+```
+
+### cdef Helper Functions
+
+Extract hot inner operations to cdef functions for inlining:
+
+```cython
+# The cdef function can be inlined by the C compiler
+cdef inline double squared_distance(double x1, double y1, double x2, double y2) noexcept nogil:
+    cdef double dx = x1 - x2
+    cdef double dy = y1 - y2
+    return dx * dx + dy * dy
+
+def nearest_neighbor(double[::1] xs, double[::1] ys, double qx, double qy):
+    cdef int i, best_i = 0
+    cdef double d, best_d = squared_distance(xs[0], ys[0], qx, qy)
+    for i in range(1, xs.shape[0]):
+        d = squared_distance(xs[i], ys[i], qx, qy)
+        if d < best_d:
+            best_d = d
+            best_i = i
+    return best_i
+```
+
+### C Math Library
+
+Replace Python math with C math for nogil compatibility and speed:
+
+```cython
+# BAD — Python math requires GIL
+import math
+result = math.sqrt(x)     # Python call → yellow line
+
+# GOOD — C math is GIL-free
+from libc.math cimport sqrt, exp, log, sin, cos, fabs, pow, floor, ceil
+result = sqrt(x)           # C call → white line
+```
+
+## Speedup Distribution
+
+From traces, speedup ranges are enormous:
+
+- **10–100x**: Typical for simple loop typing without algorithmic changes
+- **100–1,000x**: Good typing + directives + cdef helpers
+- **1,000–10,000x**: Full optimization with malloc, nogil, clean C loops
+- **10,000x+**: Problems where Python is pathologically slow (e.g., deep recursion, element-wise ops on large arrays)
+
+Most speedup comes from **typing**, not from parallelism. A well-typed single-threaded Cython function typically beats an untyped parallel one.
+
+## Trace Statistics
+
+Across ~2,800 traces from 6 categories:
+
+| Metric | Value |
+|--------|-------|
+| Overall avg annotation | 0.873 |
+| Overall avg speedup | ~3,500x |
+| Traces with errors | ~53% |
+| Timeout count | 12 |
+| Timeout fix rate | 60% |
+
+## Gotchas
+
+1. **Type before parallelize** — Typing gives 100-1000x; prange gives 2-8x on top. Do typing first.
+2. **Annotation score != speedup** — A 0.95 score with bad algorithmic complexity is still slow.
+3. **NumPy in loops** — `np.zeros()` inside a loop allocates on every iteration. Allocate once outside.
+4. **Python math** — `math.sqrt` is a Python call. Use `libc.math.sqrt` for white lines.
+5. **Integer overflow** — C `int` is 32-bit. Use `long long` for large values to avoid silent overflow.
+6. **Timeouts** — Usually from infinite loops caused by integer overflow, not from slow algorithms.
+
+## See Also
+
+[[compiler-directives]], [[typing]], [[parallelism]], [[memoryviews]]

--- a/wiki/pages/parallelism.md
+++ b/wiki/pages/parallelism.md
@@ -1,0 +1,186 @@
+# Parallelism
+
+`prange` and `nogil` for multi-threaded Cython.
+
+## Overview
+
+Cython can release the GIL and run loops in parallel via OpenMP. `prange`
+replaces `range` in for loops, distributing iterations across threads.
+Only C-typed operations (no Python objects) are allowed in `nogil` blocks.
+
+## Syntax
+
+```cython
+from cython.parallel cimport prange, parallel
+
+# Basic prange with reduction
+def sum_squares(int n):
+    cdef double total = 0.0
+    cdef int i
+    for i in prange(n, nogil=True):
+        total += <double>i * <double>i    # += is auto-reduced
+    return total
+
+# Schedule control
+for i in prange(n, nogil=True, schedule='static'):    # equal chunks (default)
+    ...
+for i in prange(n, nogil=True, schedule='dynamic'):   # work-stealing (uneven work)
+    ...
+
+# nogil block (no Python objects allowed)
+with nogil:
+    for i in range(n):
+        c_function(data[i])
+
+# Parallel block with thread-local variables
+with nogil, parallel():
+    tid = cython.parallel.threadid()
+```
+
+## GIL Violation Errors
+
+GIL violations are the **#1 parallelism error** across all trace categories. Across ~2,800 traces, 163 GIL/nogil violations were recorded.
+
+### Common Error Messages
+
+All of these mean "you're using Python objects inside a nogil block":
+
+| Error Message | Occurrences | Fix Rate |
+|--------------|-------------|----------|
+| "Calling gil-requiring function not allowed without gil" | ~40 | 84% |
+| "Coercion from Python not allowed without the GIL" | ~30 | 84% |
+| "Converting to Python object not allowed without gil" | ~20 | 84% |
+| "Constructing Python tuple not allowed without gil" | ~20 | 45% |
+| "Operation not allowed without gil" | ~15 | 84% |
+| "Indexing Python object not allowed without gil" | ~5 | 95% |
+| "Assignment of Python object not allowed without gil" | ~5 | 95% |
+
+### Pattern: Python Call in nogil
+
+```cython
+# BAD — calling Python function without GIL
+with nogil:
+    result = python_function(x)   # ERROR: Calling gil-requiring function
+
+# GOOD — use a cdef function
+cdef double c_function(double x) noexcept nogil:
+    return x * x
+
+with nogil:
+    result = c_function(x)
+```
+
+### Pattern: Constructing Python Tuples in nogil
+
+This is especially common in numerical code (45% fix rate — hardest GIL error to resolve):
+
+```cython
+# BAD — tuples are Python objects
+with nogil:
+    pair = (x, y)     # ERROR: Constructing Python tuple not allowed without gil
+
+# GOOD — use C struct or separate variables
+cdef struct Point:
+    double x
+    double y
+
+with nogil:
+    cdef Point p
+    p.x = x
+    p.y = y
+```
+
+### Pattern: Python Coercion in prange
+
+```cython
+# BAD — Python list indexing in prange
+for i in prange(n, nogil=True):
+    val = my_list[i]      # ERROR: Coercion from Python not allowed without the GIL
+
+# GOOD — use typed memoryview
+cdef double[::1] arr = np.array(my_list, dtype=np.float64)
+for i in prange(n, nogil=True):
+    val = arr[i]          # typed memoryview — no GIL needed
+```
+
+## nogil Helper Functions
+
+The `noexcept nogil` pattern is critical for helpers called in nogil blocks:
+
+```cython
+# BAD — except * (default) requires GIL for exception checking
+cdef int compare(const void *a, const void *b):    # implicit except *
+    ...
+# PERFORMANCE HINT: "Exception check on 'compare' will always require the GIL to be acquired"
+
+# GOOD — noexcept tells Cython no exception checking needed
+cdef int compare(const void *a, const void *b) noexcept nogil:
+    cdef int va = (<int *>a)[0]
+    cdef int vb = (<int *>b)[0]
+    return va - vb
+```
+
+## qsort Callback Type Signatures
+
+A frequent graph/algorithms error — qsort expects `int (*)(const void *, const void *)` with no exception clause:
+
+```cython
+from libc.stdlib cimport qsort
+
+# BAD — except * is incompatible with C function pointer
+cdef int cmp(const void *a, const void *b) except *:   # implicit default
+    ...
+qsort(arr, n, sizeof(int), cmp)
+# ERROR: "Cannot assign type 'int (*)(const void *, const void *) except *' to 'int (*)(const void *, const void *)'"
+
+# BAD — except? -1 also incompatible
+cdef int cmp(const void *a, const void *b) except? -1 nogil:
+    ...
+# ERROR: "Cannot assign type 'int (...) except? -1 nogil' to 'int (*)(...)"
+
+# GOOD — noexcept matches C function pointer type
+cdef int cmp(const void *a, const void *b) noexcept nogil:
+    return (<int *>a)[0] - (<int *>b)[0]
+
+qsort(arr, n, sizeof(int), cmp)   # works
+```
+
+This error appeared 12+ times in graph and algorithm traces.
+
+## When NOT to Use prange
+
+**Do not use prange when the Python baseline is single-threaded.** Our benchmarks compare Cython against single-threaded Python. Using prange gives an unfair multi-core advantage that doesn't reflect real Cython optimization skill.
+
+prange is appropriate when:
+- The Python baseline also uses multiprocessing/threading
+- The workload is genuinely CPU-bound and embarrassingly parallel
+- Each iteration is independent (no data dependencies)
+
+prange is inappropriate when:
+- The loop body has data dependencies between iterations
+- The workload is memory-bound (prange adds overhead, no speedup)
+- Iterations are very short (thread overhead dominates)
+
+## Fix Rates by Category
+
+| Category | GIL Violations | Fix Rate | Notes |
+|----------|---------------|----------|-------|
+| algorithms | 44 | 84% | Mostly function calls in nogil |
+| numerical | 33 | 45% | Tuple construction is hard to fix |
+| dynamic_programming | 14 | 91% | Straightforward loop patterns |
+| graph | 21 | 95% | qsort callbacks need noexcept |
+| cryptography | 42 | 51% | Complex bit operations need careful typing |
+| compression | 9 | 100% | Simple patterns, easy fixes |
+
+## Gotchas
+
+1. **No Python objects in nogil** — Strings, lists, dicts, tuples, and Python function calls all require the GIL.
+2. **prange auto-reduction** — `+=`, `-=`, `*=` are automatically reduced. Don't pass `reduction=` keyword (it doesn't exist).
+3. **noexcept for callbacks** — C function pointers (qsort, bsearch) need `noexcept` — the default `except *` is incompatible.
+4. **Performance hints** — "Exception check will always require the GIL" means add `noexcept` to avoid hidden GIL acquisition.
+5. **Thread safety** — Shared mutable state in prange causes data races. Use thread-local variables or atomic operations.
+6. **Single-threaded baselines** — Don't use prange just for benchmark numbers when Python baseline is single-threaded.
+
+## See Also
+
+[[optimization]], [[typing]], [[error-handling]], [[compiler-directives]]

--- a/wiki/pages/pitfalls.md
+++ b/wiki/pages/pitfalls.md
@@ -1,0 +1,278 @@
+# Common Pitfalls
+
+Mistakes that appear frequently in traces.
+
+## Overview
+
+These are the most common errors observed across ~2,800 agent traces attempting
+Cython optimization. Each entry includes the symptom, root cause, and fix.
+
+## Trace Statistics
+
+Aggregate error counts across 6 categories (~2,800 traces):
+
+| Error Type | Count | Fix Rate |
+|-----------|-------|----------|
+| compilation_error | ~1,935 | 74% |
+| test_failure | ~768 | — |
+| cdef_placement | ~379 | — |
+| segfault | ~245 | — |
+| gil_violation | ~152 | 75% |
+| timeout | 12 | 60% |
+
+~53% of all traces encountered at least one error requiring iteration.
+
+## Integer Overflow
+
+Python integers have arbitrary precision; C integers overflow silently.
+
+**Symptom**: Tests pass for small inputs, fail for large inputs with wrong values.
+
+```cython
+# BAD — overflows for large i
+cdef int h = i * 2654435761
+
+# GOOD — cast to prevent overflow
+cdef long long h = <long long>i * <long long>2654435761
+```
+
+## cdef After Executable Code
+
+All `cdef` declarations must come before any executable statements in a function. **379 occurrences** — the most common placement error.
+
+**Symptom**: `Cdef statement not allowed here` compilation error.
+
+```cython
+# BAD
+def func(int n):
+    x = compute()
+    cdef int i        # ERROR: cdef after executable code
+
+# GOOD
+def func(int n):
+    cdef int i
+    x = compute()
+```
+
+## Python Objects in nogil Blocks
+
+**Symptom**: `Accessing Python global or builtin not allowed without gil` compilation error.
+
+```cython
+# BAD
+with nogil:
+    result = python_function(x)   # ERROR: Python call needs GIL
+
+# GOOD
+with nogil:
+    result = c_function(x)        # cdef function, no GIL needed
+```
+
+See [[parallelism]] for comprehensive GIL violation patterns.
+
+## Uninitialized Pointers
+
+**Symptom**: Segfault (exit code -11) on first run. 245 segfaults across traces.
+
+```cython
+# BAD — no NULL check
+cdef int *arr = <int *>malloc(n * sizeof(int))
+arr[0] = 1  # segfault if malloc returns NULL
+
+# GOOD
+cdef int *arr = <int *>malloc(n * sizeof(int))
+if not arr:
+    raise MemoryError()
+```
+
+## Memory Leaks
+
+**Symptom**: ASan reports leaked bytes; clean code should score 1.0 on memory safety.
+
+```cython
+# BAD — early return leaks
+cdef int *arr = <int *>malloc(n * sizeof(int))
+if condition:
+    return -1          # LEAK: arr never freed
+
+# GOOD — free before every return path
+cdef int *arr = <int *>malloc(n * sizeof(int))
+if not arr:
+    raise MemoryError()
+try:
+    # ... use arr ...
+    result = compute(arr)
+finally:
+    free(arr)
+return result
+```
+
+## Wrong cimport Paths
+
+Agents frequently invent import paths that don't exist. This is especially common for C standard library functions.
+
+```cython
+# BAD — these paths don't exist
+from libc.stdlib cimport memset       # ERROR: 'libc/stdlib/memset.pxd' not found
+from libc.stddef cimport NULL         # ERROR: 'libc/stddef/NULL.pxd' not found
+from cpython.object cimport PyLong_FromLong  # ERROR: 'cpython/object/PyLong_FromLong.pxd' not found
+
+# GOOD — correct import paths
+from libc.string cimport memset, memcpy, memcmp   # memset is in libc.string
+from libc.stdlib cimport malloc, free, calloc      # NULL is implicitly available
+from cpython.long cimport PyLong_FromLong          # if you really need it (usually don't)
+```
+
+This error appeared 20+ times across algorithm, dynamic_programming, and graph traces. The most common: `memset` is in `libc.string`, not `libc.stdlib`.
+
+## Closures Inside cpdef
+
+```cython
+# BAD — cpdef cannot contain closures
+cpdef list sort_items(list data):
+    def key_fn(x):          # ERROR: closures inside cpdef functions not yet supported
+        return x[1]
+    return sorted(data, key=key_fn)
+
+# GOOD — use def instead
+def sort_items(list data):
+    def key_fn(x):
+        return x[1]
+    return sorted(data, key=key_fn)
+```
+
+Appeared 15+ times across compression and cryptography traces.
+
+## Storing Unsafe C Derivative of Temporary Python Reference
+
+Taking a C pointer to a Python object that may be garbage collected.
+
+```cython
+# BAD — temporary bytes object may be freed
+cdef const unsigned char* data = some_string.encode('utf-8')
+# WARNING: Storing unsafe C derivative of temporary Python reference
+
+# GOOD — keep reference alive
+encoded = some_string.encode('utf-8')
+cdef const unsigned char* data = encoded
+
+# Also BAD with numpy
+cdef double* ptr = <double*>np.zeros(10).data   # temporary ndarray!
+# GOOD
+arr = np.zeros(10)
+cdef double* ptr = <double*>arr.data
+```
+
+This warning appeared 25+ times across dynamic_programming, algorithms, and numerical traces.
+
+## Cannot Coerce Python List to Memoryview
+
+```cython
+# BAD — Python lists aren't buffers
+cdef int[::1] arr = [0] * n    # ERROR: Cannot coerce multiplied list to 'int[:]'
+cdef int[:] view = [1, 2, 3]   # ERROR
+
+# GOOD — use numpy
+import numpy as np
+cdef int[::1] arr = np.zeros(n, dtype=np.intc)
+```
+
+14+ occurrences in graph traces. See [[memoryviews]] for more.
+
+## Casting Python Objects to C Pointers
+
+```cython
+# BAD — Python object to primitive pointer
+cdef int* ptr = <int*>python_list
+# ERROR: Casting temporary Python object to non-numeric non-Python type
+# ERROR: Python objects cannot be cast to pointers of primitive types
+
+# GOOD — go through numpy or malloc
+import numpy as np
+arr = np.array(python_list, dtype=np.intc)
+cdef int[::1] view = arr
+```
+
+6+ occurrences in dynamic_programming traces.
+
+## Variable Redeclaration
+
+```cython
+# BAD — declaring same variable twice
+def func(int n):
+    cdef int idx
+    cdef int idx        # ERROR: 'idx' redeclared
+
+# GOOD — declare once
+def func(int n):
+    cdef int idx
+```
+
+## Special Methods with cdef
+
+```cython
+# BAD — cdef for special methods
+cdef class Node:
+    cdef int __len__(self):   # ERROR: Special methods must be declared with 'def', not 'cdef'
+        return self.size
+
+# GOOD
+cdef class Node:
+    def __len__(self):
+        return self.size
+```
+
+See [[extension-types]] for more on cdef classes.
+
+## Undeclared malloc/free
+
+```cython
+# BAD — using malloc without cimport
+cdef int* arr = <int*>malloc(n * sizeof(int))
+# ERROR: undeclared name not builtin: malloc
+
+# GOOD — cimport first
+from libc.stdlib cimport malloc, free
+cdef int* arr = <int*>malloc(n * sizeof(int))
+```
+
+Appeared 20+ times across all categories. See [[memory-management]].
+
+## Invalid prange Keywords
+
+```cython
+# BAD — 'reduction' is not a valid prange keyword
+for i in prange(n, nogil=True, reduction='+'):
+    total += arr[i]
+# ERROR: Invalid keyword argument: reduction
+
+# GOOD — prange auto-detects reductions from +=, *=, etc.
+for i in prange(n, nogil=True):
+    total += arr[i]    # auto-reduced
+```
+
+22 occurrences in numerical traces. See [[parallelism]].
+
+## Unrecognized Characters
+
+```cython
+# BAD — Unicode or special characters in .pyx files
+# Often from copy-pasting from documentation with smart quotes or non-ASCII
+# ERROR: Unrecognized character
+
+# GOOD — ensure file is clean ASCII/UTF-8 with no BOM
+```
+
+## Not Allowed in Constant Expression
+
+```cython
+# BAD — using runtime values in compile-time contexts
+DEF SIZE = len(some_list)    # ERROR: Not allowed in a constant expression
+
+# GOOD — use literal constants
+DEF SIZE = 256
+```
+
+## See Also
+
+[[typing]], [[memory-management]], [[c-interop]], [[parallelism]], [[error-handling]]

--- a/wiki/pages/typing.md
+++ b/wiki/pages/typing.md
@@ -1,0 +1,216 @@
+# Typing
+
+Static type declarations for C-speed execution.
+
+## Overview
+
+Cython's main performance lever: declaring C types removes Python object overhead
+from hot paths. Variables, function parameters, and return types can all be typed.
+
+## Syntax
+
+```cython
+# Variable declarations (must be at function top, before executable code)
+cdef int i
+cdef double total = 0.0
+cdef long long big_num
+
+# Function declarations
+cdef double fast_internal(double x, double y):    # C-only, not callable from Python
+    return x * y
+
+cpdef double both_ways(double x, double y):       # callable from C and Python
+    return x * y
+
+def python_visible(int n):                        # Python-callable with typed params
+    cdef int i
+    for i in range(n): ...
+
+# Fused types (generics)
+ctypedef fused number_t:
+    int
+    long long
+    float
+    double
+
+def generic_sum(number_t[:] arr):
+    cdef number_t total = 0
+    for i in range(arr.shape[0]):
+        total += arr[i]
+    return total
+
+# Type aliases
+ctypedef unsigned long long uint64
+ctypedef double (*func_ptr)(double)
+```
+
+## Patterns
+
+### Declare All C Variables at Function Top
+
+All `cdef` declarations must appear before any executable statements in a function body. This is the single most common typing error in traces (229+ occurrences across categories).
+
+```cython
+# BAD — cdef after executable code
+def func(int n):
+    result = []
+    cdef int i          # ERROR: cdef statement not allowed here
+
+# GOOD — all cdef declarations at the top
+def func(int n):
+    cdef int i
+    result = []
+```
+
+### Variable Redeclaration
+
+Declaring the same variable twice in different scopes causes errors.
+
+```cython
+# BAD — redeclared variable
+def func(int n):
+    cdef int idx
+    for idx in range(n):
+        ...
+    cdef int idx        # ERROR: 'idx' redeclared
+
+# GOOD — declare once, reuse
+def func(int n):
+    cdef int idx
+    for idx in range(n):
+        ...
+    # reuse idx freely after loop
+```
+
+### Special Methods Must Use `def`
+
+Cython extension type special methods (`__len__`, `__getitem__`, etc.) must be declared with `def`, not `cdef` or `cpdef`.
+
+```cython
+# BAD — special methods cannot be cdef
+cdef class MyContainer:
+    cdef int __len__(self):       # ERROR: Special methods must be declared with 'def', not 'cdef'
+        return self.size
+
+# GOOD
+cdef class MyContainer:
+    def __len__(self):
+        return self.size
+```
+
+### Closures Inside cpdef
+
+`cpdef` functions cannot contain closures or inner functions that capture local variables.
+
+```cython
+# BAD — closure inside cpdef
+cpdef list sort_custom(list items):
+    def key_func(x):       # ERROR: closures not supported in cpdef
+        return x.value
+    return sorted(items, key=key_func)
+
+# GOOD — use def instead, or extract to module-level
+def sort_custom(list items):
+    def key_func(x):
+        return x.value
+    return sorted(items, key=key_func)
+```
+
+### Syntax Errors in C Variable Declarations
+
+Using Python-style type hints or invalid C syntax in `cdef` declarations. This is the top compilation error (9 occurrences in algorithms alone).
+
+```cython
+# BAD — Python annotation syntax in cdef
+cdef int x: int = 0              # ERROR: Syntax error in C variable declaration
+
+# BAD — missing type
+cdef = 0                         # ERROR
+
+# GOOD — standard cdef syntax
+cdef int x = 0
+```
+
+### Storing Unsafe C Derivative of Temporary Python Reference
+
+Taking a C pointer to a temporary Python object that may be garbage collected.
+
+```cython
+# BAD — pointer to temporary
+cdef const char* s = some_string.encode('utf-8')  # WARNING: Storing unsafe C derivative of temporary Python reference
+
+# GOOD — keep a reference alive
+py_bytes = some_string.encode('utf-8')
+cdef const char* s = py_bytes
+```
+
+### Type Identifiers Require cimport
+
+Using C++ STL types or external types requires proper cimport.
+
+```cython
+# BAD — using type without cimport
+cdef priority_queue[int] pq     # ERROR: 'priority_queue' is not a type identifier
+
+# GOOD — cimport first
+from libcpp.queue cimport priority_queue
+cdef priority_queue[int] pq
+```
+
+### Multiplied List to Memoryview Coercion
+
+Python list expressions cannot be directly assigned to typed memoryviews.
+
+```cython
+# BAD — list literal to memoryview
+cdef int[:] arr = [0] * n       # ERROR: cannot coerce list to memoryview
+
+# GOOD — create numpy array, then assign
+import numpy as np
+cdef int[:] arr = np.zeros(n, dtype=np.intc)
+```
+
+### Python Object to C Pointer Conversion
+
+Cannot implicitly convert Python objects to C pointers.
+
+```cython
+# BAD — implicit conversion
+cdef int* ptr = python_list     # ERROR: Cannot convert Python object to pointer
+
+# GOOD — use typed memoryview or malloc
+cdef int[:] view = np.array(python_list, dtype=np.intc)
+# or
+cdef int* ptr = <int*>malloc(n * sizeof(int))
+```
+
+## Trace Statistics
+
+Across 500 algorithm traces (representative sample):
+
+| Error Type | Count | Fix Rate |
+|-----------|-------|----------|
+| cdef placement | 77 | ~72% (single-step) |
+| Syntax in C variable decl | 9+ | High |
+| Unsafe temporary reference | 3+ | High |
+| Type identifier missing | 4+ | High |
+| Variable redeclaration | 2+ | High |
+| Special method with cdef | 2+ | High |
+
+**Key insight**: cdef placement is the #1 typing error. Always declare all C variables at the function top, before any assignments, calls, or control flow.
+
+## Gotchas
+
+1. **cdef before code** — Every `cdef` must precede all executable statements. Even `x = 0` counts as executable.
+2. **No redeclaration** — Cannot `cdef` the same variable name twice in one scope.
+3. **int overflow** — Python `int` is arbitrary precision; C `int` overflows silently. Use `long long` for large values.
+4. **fused types need memoryviews** — `ctypedef fused` works with typed memoryviews, not raw Python lists.
+5. **`def` for special methods** — `__init__`, `__len__`, `__getitem__` etc. must always use `def`.
+6. **cpdef limitations** — No closures, no `*args`/`**kwargs`, no generators.
+7. **cimport vs import** — C types need `cimport`; regular Python imports won't make C types available.
+8. **Temporary references** — Keep Python objects alive when taking C pointers to their data.
+9. **Multiplied lists** — `[0] * n` is a Python list, not a C array. Use numpy or malloc.
+
+## See Also
+
+[[extension-types]], [[compiler-directives]], [[enums-tuples]], [[pitfalls]], [[c-interop]]

--- a/wiki/schema.md
+++ b/wiki/schema.md
@@ -1,0 +1,69 @@
+# Wiki Schema
+
+This wiki is an LLM-maintained knowledge base for Cython optimization patterns.
+It sits between raw sources (Cython docs, our cy/ implementations, traces) and
+the agents that write Cython code.
+
+## Raw Sources (read-only, never modified by the wiki)
+
+- `.sources/cython-docs/` — official Cython documentation (gitignored)
+- `cnake_data/cy/` — our 500+ Cython implementations across 19 categories
+- `data/traces/master_traces.jsonl` — 10K+ agent traces with error/fix patterns
+
+## Page Template
+
+Every page in `pages/` should follow this structure:
+
+```markdown
+# Page Title
+
+One-line summary of what this page covers.
+
+## Overview
+
+Brief explanation of the concept and when to use it.
+
+## Syntax
+
+Core syntax examples with minimal explanation.
+
+## Patterns
+
+Real-world patterns extracted from our codebase and traces.
+Each pattern should include:
+- The Cython code
+- Why it's fast (what C-level optimization it enables)
+- Source attribution (cy/ file or trace if applicable)
+
+## Gotchas
+
+Common mistakes observed in traces. Each gotcha should include:
+- What goes wrong
+- How it manifests (compilation error, segfault, wrong output)
+- The fix
+
+## See Also
+
+Cross-references to related pages: [[page-name]]
+```
+
+## Conventions
+
+- **Filenames**: kebab-case, `.md` extension (e.g., `memory-management.md`)
+- **Cross-references**: `[[page-name]]` or `[[page-name#section]]`
+- **Code blocks**: Always use `cython` language tag for Cython code
+- **Source attribution**: Note where content came from (`Source: cy/numerical/great_circle.pyx` or `Source: traces, 47 occurrences`)
+- **No duplication**: If content belongs on another page, link to it instead
+- **Examples over prose**: Show the code, explain briefly why it works
+
+## Operations
+
+- **Ingest**: Read a raw source, extract insights, update relevant pages
+- **Reflect**: Analyze traces for patterns, update Gotchas and Patterns sections
+- **Lint**: Check for orphaned pages, broken cross-refs, stale content
+
+## Special Files
+
+- `index.md` — content catalog, updated whenever pages are added/modified
+- `log.md` — append-only record of all wiki operations
+- `schema.md` — this file, the rules of the wiki


### PR DESCRIPTION
…fety

Add wiki_read and wiki_search as read-only tools during trace collection and GRPO training (2-call cap per episode), extract reusable wiki module from mcp_server, add DSPy ReAct reflection agent for LLM-powered wiki curation, and page-level flock locking for concurrent write safety.

Phase 1: cnake_charmer/wiki/search.py extracted from mcp_server.py Phase 2: wiki tools wired into dspy_agent, environment, traces/lm,
         collect_traces, train_grpo, tools.json, system_prompt
Phase 3: cnake_charmer/wiki/merge.py with atomic_wiki_write + fcntl.flock Phase 4: wiki/trace_analysis.py (code diffs), wiki/llm_reflect.py
         (DSPy ReAct curator), updated scripts/wiki_reflect.py with
         --llm/--apply/--dry-run modes